### PR TITLE
Add extensive game balancing config

### DIFF
--- a/v1/config.json
+++ b/v1/config.json
@@ -24,5 +24,22 @@
   "W": 1,
   "X": 1,
   "Y": 1,
-  "Z": 1
+  "Z": 1,
+
+  "tower_damage": 1,
+  "tower_range": 500,
+  "tower_fire_rate": 100,
+  "tower_ammo_capacity": 5,
+  "tower_projectiles_per_shot": 1,
+  "tower_bounce_count": 0,
+
+  "projectile_speed": 5.0,
+
+  "base_health": 10,
+
+  "mob_speed": 1.0,
+  "mob_base_health": 1,
+  "mobs_per_wave_base": 3,
+  "mobs_per_wave_growth": 3,
+  "spawn_interval": 60
 }

--- a/v1/internal/game/config.go
+++ b/v1/internal/game/config.go
@@ -36,6 +36,25 @@ type Config struct {
 	X float64
 	Y float64
 	Z float64
+
+	// Explicitly named parameters used throughout the game. All values are
+	// optional when loading from JSON; zero values fall back to defaults.
+	TowerDamage       int     `json:"tower_damage"`
+	TowerRange        float64 `json:"tower_range"`
+	TowerFireRate     int     `json:"tower_fire_rate"`
+	TowerAmmoCapacity int     `json:"tower_ammo_capacity"`
+	TowerProjectiles  int     `json:"tower_projectiles_per_shot"`
+	TowerBounce       int     `json:"tower_bounce_count"`
+
+	ProjectileSpeed float64 `json:"projectile_speed"`
+
+	BaseHealth int `json:"base_health"`
+
+	MobSpeed       float64 `json:"mob_speed"`
+	MobBaseHealth  int     `json:"mob_base_health"`
+	MobsPerWave    int     `json:"mobs_per_wave_base"`
+	MobsPerWaveInc int     `json:"mobs_per_wave_growth"`
+	SpawnInterval  int     `json:"spawn_interval"`
 }
 
 // DefaultConfig provides baseline parameters used when a new game starts.
@@ -66,6 +85,24 @@ var DefaultConfig = Config{
 	X: 1,
 	Y: 1,
 	Z: 1,
+
+	// Defaults for the new explicit parameters
+	TowerDamage:       1,
+	TowerRange:        500,
+	TowerFireRate:     100,
+	TowerAmmoCapacity: 5,
+	TowerProjectiles:  1,
+	TowerBounce:       0,
+
+	ProjectileSpeed: 5.0,
+
+	BaseHealth: 10,
+
+	MobSpeed:       1.0,
+	MobBaseHealth:  1,
+	MobsPerWave:    3,
+	MobsPerWaveInc: 3,
+	SpawnInterval:  60,
 }
 
 // LoadConfig reads configuration values from the given JSON file.

--- a/v1/internal/game/mob.go
+++ b/v1/internal/game/mob.go
@@ -14,7 +14,7 @@ type Mob struct {
 }
 
 // NewMob returns a new mob at the given position.
-func NewMob(x, y float64, target *Base, hp int) *Mob {
+func NewMob(x, y float64, target *Base, hp int, speed float64) *Mob {
 	w, h := ImgMobA.Bounds().Dx(), ImgMobA.Bounds().Dy()
 	return &Mob{
 		BaseEntity: BaseEntity{
@@ -25,7 +25,7 @@ func NewMob(x, y float64, target *Base, hp int) *Mob {
 			frameAnchorX: float64(w) / 2,
 			frameAnchorY: float64(h) / 2,
 		},
-		speed:  1,
+		speed:  speed,
 		alive:  true,
 		target: target,
 		health: hp,

--- a/v1/internal/game/projectile_test.go
+++ b/v1/internal/game/projectile_test.go
@@ -3,8 +3,9 @@ package game
 import "testing"
 
 func TestProjectileIntercept(t *testing.T) {
-	mob := NewMob(200, 100, nil, 1)
-	p := NewProjectile(100, 100, mob)
+	mob := NewMob(200, 100, nil, 1, 1)
+	g := &Game{mobs: []*Mob{mob}}
+	p := NewProjectile(g, 100, 100, mob, 1, 5, 0)
 	for i := 0; i < 200 && mob.alive && p.alive; i++ {
 		mob.Update()
 		p.Update()


### PR DESCRIPTION
## Summary
- expand `Config` with explicit tunable fields
- add defaults for tower, projectile and mob parameters
- load new fields from `config.json`
- apply config in tower behaviour and game spawning logic
- extend projectile to support damage and bouncing
- update tests for new constructors

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fbcb67cb48327b7db7cd7898ae416