### PR TITLE
Implement keyboard tower placement

### DIFF
--- a/v1/config.json
+++ b/v1/config.json
@@ -33,6 +33,7 @@
   "tower_ammo_capacity": 5,
   "tower_projectiles_per_shot": 1,
   "tower_bounce_count": 0,
+  "tower_construction_cost": 20,
 
   "projectile_speed": 3.05,
 

--- a/v1/internal/game/build_test.go
+++ b/v1/internal/game/build_test.go
@@ -1,0 +1,20 @@
+package game
+
+import "testing"
+
+func TestBuildTowerCostsGold(t *testing.T) {
+	cfg := DefaultConfig
+	cfg.TowerConstructionCost = 5
+	g := NewGameWithConfig(cfg)
+	g.gold = 10
+	g.cursorX = 4
+	g.cursorY = 4
+	initial := len(g.towers)
+	g.buildTowerAtCursor()
+	if len(g.towers) != initial+1 {
+		t.Fatalf("expected tower count %d got %d", initial+1, len(g.towers))
+	}
+	if g.gold != 5 {
+		t.Fatalf("expected gold 5 got %d", g.gold)
+	}
+}

--- a/v1/internal/game/config.go
+++ b/v1/internal/game/config.go
@@ -41,10 +41,12 @@ type Config struct {
 	// optional when loading from JSON; zero values fall back to defaults.
 	TowerDamage       int     `json:"tower_damage"`
 	TowerRange        float64 `json:"tower_range"`
-	TowerFireRate     float64 `json:"tower_fire_rate"`   // milliseconds between shots
+	TowerFireRate     float64 `json:"tower_fire_rate"` // milliseconds between shots
 	TowerAmmoCapacity int     `json:"tower_ammo_capacity"`
 	TowerProjectiles  int     `json:"tower_projectiles_per_shot"`
 	TowerBounce       int     `json:"tower_bounce_count"`
+
+	TowerConstructionCost int `json:"tower_construction_cost"`
 
 	ProjectileSpeed float64 `json:"projectile_speed"`
 
@@ -93,6 +95,8 @@ var DefaultConfig = Config{
 	TowerAmmoCapacity: 5,
 	TowerProjectiles:  1,
 	TowerBounce:       0,
+
+	TowerConstructionCost: 20,
 
 	ProjectileSpeed: 5.0,
 

--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
+	"github.com/hajimehoshi/ebiten/v2/vector"
 )
 
 var (
@@ -62,6 +63,9 @@ type Game struct {
 	letterPool  []rune
 	unlockStage int
 
+	cursorX int
+	cursorY int
+
 	lastUpdate time.Time
 }
 
@@ -93,6 +97,8 @@ func NewGameWithConfig(cfg Config) *Game {
 		projectiles: make([]*Projectile, 0),
 		letterPool:  make([]rune, 0),
 		unlockStage: 0,
+		cursorX:     2,
+		cursorY:     16,
 	}
 
 	tx, ty := tilePosition(1, 16)
@@ -123,7 +129,36 @@ func (g *Game) Update() error {
 	}
 	g.lastUpdate = now
 	g.input.Update()
-	g.input.Update()
+
+	if !g.shopOpen {
+		if g.input.Left() {
+			g.cursorX--
+		}
+		if g.input.Right() {
+			g.cursorX++
+		}
+		if g.input.Up() {
+			g.cursorY--
+		}
+		if g.input.Down() {
+			g.cursorY++
+		}
+		if g.cursorX < 0 {
+			g.cursorX = 0
+		}
+		if g.cursorX > 59 {
+			g.cursorX = 59
+		}
+		if g.cursorY < 0 {
+			g.cursorY = 0
+		}
+		if g.cursorY > 33 {
+			g.cursorY = 33
+		}
+		if g.input.Build() {
+			g.buildTowerAtCursor()
+		}
+	}
 
 	if g.input.Reload() {
 		if err := g.reloadConfig(ConfigFile); err != nil {
@@ -272,6 +307,17 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		m.Draw(g.screen)
 	}
 
+	if !g.shopOpen {
+		op := &ebiten.DrawImageOptions{}
+		op.GeoM.Translate(float64(g.cursorX*TileSize), float64(TopMargin+g.cursorY*TileSize))
+		if g.validTowerPosition(g.cursorX, g.cursorY) {
+			g.screen.DrawImage(ImgHighlightTile, op)
+		} else {
+			// draw red rectangle for invalid position
+			vector.DrawFilledRect(g.screen, float32(g.cursorX*TileSize), float32(TopMargin+g.cursorY*TileSize), float32(TileSize), float32(TileSize), color.RGBA{255, 0, 0, 100}, false)
+		}
+	}
+
 	if g.paused {
 		opts := &text.DrawOptions{}
 		opts.GeoM.Translate(900, 520)
@@ -331,6 +377,46 @@ func (g *Game) spawnMob() {
 	}
 	m := NewMob(float64(x+16), float64(y+16), g.base, hp, speed)
 	g.mobs = append(g.mobs, m)
+}
+
+func (g *Game) validTowerPosition(tileX, tileY int) bool {
+	if tileX < 0 || tileX > 59 || tileY < 0 || tileY > 33 {
+		return false
+	}
+	tx, ty := tilePosition(tileX, tileY)
+	px := float64(tx + TileSize/2)
+	py := float64(ty + TileSize/2)
+	bx, by, bw, bh := g.base.Bounds()
+	if int(px) >= bx && int(px) <= bx+bw && int(py) >= by && int(py) <= by+bh {
+		return false
+	}
+	for _, t := range g.towers {
+		x, y, w, h := t.Bounds()
+		if int(px) >= x && int(px) <= x+w && int(py) >= y && int(py) <= y+h {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *Game) buildTowerAtCursor() {
+	if g.cfg == nil {
+		return
+	}
+	cost := g.cfg.TowerConstructionCost
+	if cost == 0 {
+		cost = DefaultConfig.TowerConstructionCost
+	}
+	if g.gold < cost {
+		return
+	}
+	if !g.validTowerPosition(g.cursorX, g.cursorY) {
+		return
+	}
+	tx, ty := tilePosition(g.cursorX, g.cursorY)
+	t := NewTower(g, float64(tx+TileSize/2), float64(ty+TileSize/2))
+	g.towers = append(g.towers, t)
+	g.gold -= cost
 }
 
 // startWave initializes spawn counters for the next wave.

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -87,6 +87,11 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 			lines = append(lines, fmt.Sprintf("Base HP: %d", h.game.base.Health()))
 		}
 		lines = append(lines, fmt.Sprintf("Wave %d | Gold %d | Mobs %d", h.game.currentWave, h.game.gold, len(h.game.mobs)))
+		cost := h.game.cfg.TowerConstructionCost
+		if cost == 0 {
+			cost = DefaultConfig.TowerConstructionCost
+		}
+		lines = append(lines, fmt.Sprintf("[h/j/k/l] move cursor | [b] build (%d gold)", cost))
 	}
 
 	if len(lines) == 0 {

--- a/v1/internal/game/input.go
+++ b/v1/internal/game/input.go
@@ -14,6 +14,11 @@ type InputHandler interface {
 	Quit() bool         // Quit returns whether the game should quit
 	Reload() bool       // Reload returns whether config reload was requested
 	Enter() bool        // Enter reports if the enter key was pressed
+	Left() bool
+	Right() bool
+	Up() bool
+	Down() bool
+	Build() bool
 }
 
 type Input struct {
@@ -23,6 +28,11 @@ type Input struct {
 	space     bool   // Whether space was pressed this frame
 	reload    bool   // Whether F5 was pressed this frame
 	enter     bool   // Whether enter was pressed this frame
+	left      bool
+	right     bool
+	up        bool
+	down      bool
+	build     bool
 }
 
 // NewInput creates a new Input instance with default values.
@@ -34,6 +44,11 @@ func NewInput() *Input {
 		space:     false,
 		reload:    false,
 		enter:     false,
+		left:      false,
+		right:     false,
+		up:        false,
+		down:      false,
+		build:     false,
 	}
 }
 
@@ -47,6 +62,11 @@ func (i *Input) Update() {
 	i.space = inpututil.IsKeyJustPressed(ebiten.KeySpace)
 	i.reload = inpututil.IsKeyJustPressed(ebiten.KeyF5)
 	i.enter = inpututil.IsKeyJustPressed(ebiten.KeyEnter)
+	i.left = inpututil.IsKeyJustPressed(ebiten.KeyH) || inpututil.IsKeyJustPressed(ebiten.KeyArrowLeft)
+	i.right = inpututil.IsKeyJustPressed(ebiten.KeyL) || inpututil.IsKeyJustPressed(ebiten.KeyArrowRight)
+	i.up = inpututil.IsKeyJustPressed(ebiten.KeyK) || inpututil.IsKeyJustPressed(ebiten.KeyArrowUp)
+	i.down = inpututil.IsKeyJustPressed(ebiten.KeyJ) || inpututil.IsKeyJustPressed(ebiten.KeyArrowDown)
+	i.build = inpututil.IsKeyJustPressed(ebiten.KeyB)
 }
 
 // Reset resets the Input state to its default values.
@@ -57,6 +77,11 @@ func (i *Input) Reset() {
 	i.space = false
 	i.reload = false
 	i.enter = false
+	i.left = false
+	i.right = false
+	i.up = false
+	i.down = false
+	i.build = false
 }
 
 // Quit returns whether the game should quit.
@@ -88,3 +113,9 @@ func (i *Input) Reload() bool {
 func (i *Input) Enter() bool {
 	return i.enter
 }
+
+func (i *Input) Left() bool  { return i.left }
+func (i *Input) Right() bool { return i.right }
+func (i *Input) Up() bool    { return i.up }
+func (i *Input) Down() bool  { return i.down }
+func (i *Input) Build() bool { return i.build }


### PR DESCRIPTION
## Summary
- allow building new towers with keyboard controls
- add TowerConstructionCost to config and defaults
- highlight cursor location on the grid
- track cursor with h/j/k/l navigation and build with `b`
- show placement hints in HUD
- include test for tower placement cost

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68409e842b9c8327962a0223a385e59c