### PR TITLE
Implement basic shop navigation and foresight upgrade

### DIFF
--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -31,14 +31,32 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 		gold := h.game.gold
 		lines = append(lines, "-- SHOP --")
 		lines = append(lines, fmt.Sprintf("Gold: %d", gold))
-		lines = append(lines, "[1] Upgrade Damage (+1): 5 gold")
-		lines = append(lines, "[2] Upgrade Range (+50): 5 gold")
-		lines = append(lines, "[3] Upgrade Fire Rate (faster): 5 gold")
-		lines = append(lines, "[4] Upgrade Ammo Capacity (+2): 10 gold")
-		lines = append(lines, "Press Enter to start next wave")
+
+		var foresight int
+		if len(h.game.towers) > 0 {
+			foresight = h.game.towers[h.game.selectedTower].foresight
+		}
+
+		options := []string{
+			"[1] Upgrade Damage (+1): 5 gold",
+			"[2] Upgrade Range (+50): 5 gold",
+			"[3] Upgrade Fire Rate (faster): 5 gold",
+			"[4] Upgrade Ammo Capacity (+2): 10 gold",
+			fmt.Sprintf("[5] Foresight (+2 letters) [%d]", foresight),
+			"Start Next Wave",
+		}
+
+		for i, opt := range options {
+			prefix := "  "
+			if i == h.game.shopCursor {
+				prefix = "> "
+			}
+			lines = append(lines, prefix+opt)
+		}
 	} else {
 		if len(h.game.towers) > 0 {
-			t := h.game.towers[0]
+			t := h.game.towers[h.game.selectedTower]
+			lines = append(lines, fmt.Sprintf("Selected Tower: %d", h.game.selectedTower+1))
 			currentAmmo, maxAmmo := t.GetAmmoStatus()
 			lines = append(lines, fmt.Sprintf("Ammo: %d/%d", currentAmmo, maxAmmo))
 			lines = append(lines, fmt.Sprintf("Damage: %d", t.damage))
@@ -56,11 +74,10 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 				lines = append(lines, fmt.Sprintf("Stuck on: '%c'", currentLetter))
 			} else if reloading {
 				if timer <= 0 {
-					// Show current letter and preview queue
 					queueStr := ""
 					for i, letter := range previewQueue {
 						if i == 0 {
-							queueStr += fmt.Sprintf("[%c]", letter) // Current letter in brackets
+							queueStr += fmt.Sprintf("[%c]", letter)
 						} else {
 							queueStr += fmt.Sprintf(" %c", letter)
 						}

--- a/v1/internal/game/input.go
+++ b/v1/internal/game/input.go
@@ -11,6 +11,8 @@ type InputHandler interface {
 	Reset()             // Reset resets the Input state to its default values
 	Backspace() bool    // Backspace reports if backspace was pressed since the last Update call
 	Space() bool        // Space reports if the space bar was pressed since the last Update call
+	Up() bool           // Up reports if the 'k' key or up arrow was pressed
+	Down() bool         // Down reports if the 'j' key or down arrow was pressed
 	Quit() bool         // Quit returns whether the game should quit
 	Reload() bool       // Reload returns whether config reload was requested
 	Enter() bool        // Enter reports if the enter key was pressed
@@ -23,6 +25,8 @@ type Input struct {
 	space     bool   // Whether space was pressed this frame
 	reload    bool   // Whether F5 was pressed this frame
 	enter     bool   // Whether enter was pressed this frame
+	up        bool   // Whether 'k' or up arrow was pressed this frame
+	down      bool   // Whether 'j' or down arrow was pressed this frame
 }
 
 // NewInput creates a new Input instance with default values.
@@ -34,6 +38,8 @@ func NewInput() *Input {
 		space:     false,
 		reload:    false,
 		enter:     false,
+		up:        false,
+		down:      false,
 	}
 }
 
@@ -47,6 +53,8 @@ func (i *Input) Update() {
 	i.space = inpututil.IsKeyJustPressed(ebiten.KeySpace)
 	i.reload = inpututil.IsKeyJustPressed(ebiten.KeyF5)
 	i.enter = inpututil.IsKeyJustPressed(ebiten.KeyEnter)
+	i.up = inpututil.IsKeyJustPressed(ebiten.KeyK) || inpututil.IsKeyJustPressed(ebiten.KeyArrowUp)
+	i.down = inpututil.IsKeyJustPressed(ebiten.KeyJ) || inpututil.IsKeyJustPressed(ebiten.KeyArrowDown)
 }
 
 // Reset resets the Input state to its default values.
@@ -57,6 +65,8 @@ func (i *Input) Reset() {
 	i.space = false
 	i.reload = false
 	i.enter = false
+	i.up = false
+	i.down = false
 }
 
 // Quit returns whether the game should quit.
@@ -87,4 +97,14 @@ func (i *Input) Reload() bool {
 // Enter reports if the enter key was pressed since the last Update call.
 func (i *Input) Enter() bool {
 	return i.enter
+}
+
+// Up reports if the 'k' key or up arrow was pressed since the last Update call.
+func (i *Input) Up() bool {
+	return i.up
+}
+
+// Down reports if the 'j' key or down arrow was pressed since the last Update call.
+func (i *Input) Down() bool {
+	return i.down
 }

--- a/v1/internal/game/input_test.go
+++ b/v1/internal/game/input_test.go
@@ -3,12 +3,17 @@ package game
 import "testing"
 
 func TestInputReset(t *testing.T) {
-	in := NewInput()
-	in.quit = true
-	in.Reset()
-	if in.quit != false {
-		t.Errorf("expected quit false got %v", in.quit)
-	}
+       in := NewInput()
+       in.quit = true
+       in.up = true
+       in.down = true
+       in.Reset()
+       if in.quit != false {
+               t.Errorf("expected quit false got %v", in.quit)
+       }
+       if in.up || in.down {
+               t.Errorf("expected direction keys reset")
+       }
 }
 
 func TestInputQuit(t *testing.T) {

--- a/v1/internal/game/tower.go
+++ b/v1/internal/game/tower.go
@@ -27,6 +27,7 @@ type Tower struct {
 	bounce       int
 	jammed       bool
 	jammedLetter rune // preserve letter when jammed
+	foresight    int  // number of reload letters to preview
 }
 
 // NewTower creates a new Tower at the given position.
@@ -50,6 +51,7 @@ func NewTower(g *Game, x, y float64) *Tower {
 		projectiles:  DefaultConfig.TowerProjectiles,
 		bounce:       DefaultConfig.TowerBounce,
 		jammed:       false,
+		foresight:    5,
 	}
 
 	// Initialize ammo queue with full capacity
@@ -298,9 +300,8 @@ func (t *Tower) GetReloadStatus() (bool, rune, []rune, float64, bool) {
 		currentLetter = t.reloadQueue[0]
 	}
 
-	// Return up to 5 letters for preview (future "Foresight" upgrade)
-	previewQueue := make([]rune, 0, 5)
-	for i := 0; i < len(t.reloadQueue) && i < 5; i++ {
+	previewQueue := make([]rune, 0, t.foresight)
+	for i := 0; i < len(t.reloadQueue) && i < t.foresight; i++ {
 		previewQueue = append(previewQueue, t.reloadQueue[i])
 	}
 
@@ -323,6 +324,17 @@ func (t *Tower) UpgradeAmmoCapacity(increase int) {
 		newAmmoQueue[i] = true // New slots start loaded
 	}
 	t.ammoQueue = newAmmoQueue
+}
+
+// UpgradeForesight increases how many reload letters are previewed
+func (t *Tower) UpgradeForesight(increase int) {
+	if increase <= 0 {
+		return
+	}
+	t.foresight += increase
+	if t.foresight > 10 {
+		t.foresight = 10
+	}
 }
 
 // Draw renders the tower and its range indicator.


### PR DESCRIPTION
## Summary
- allow keyboard up/down navigation via Input
- select towers and shop options with Vim-like keys
- add Foresight upgrade and preview count support
- highlight selected tower in HUD and draw loop

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68409f802fa08327921e7f7502aac825