### PR TITLE
Implement typing performance modifiers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ Code should be formatted with `gofmt` and accompanied by unit tests when possibl
 - Bouncing projectile mechanics
 - Upgrade purchasing system using gold between waves (damage, range, fire rate upgrades implemented and tested)
 - **Keyboard-driven navigation for all menus and gameplay**
+- Typing accuracy and WPM tracking with bonuses and penalties
 
 ## Automation
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -52,11 +52,11 @@
 
 ### Typing Performance Modifiers
 
-- [ ] Track typing accuracy for reloads/targeting.
-- [ ] Track typing speed (WPM or similar metric).
-- [ ] Implement: Reload speed bonuses for fast/accurate typing.
-- [ ] Implement: Penalties for slow/inaccurate typing (e.g., increased reload time, temporary jam).
-- [ ] UI: Display basic typing stats (accuracy, WPM) in HUD.
+- [x] Track typing accuracy for reloads/targeting.
+- [x] Track typing speed (WPM or similar metric).
+- [x] Implement: Reload speed bonuses for fast/accurate typing.
+- [x] Implement: Penalties for slow/inaccurate typing (e.g., increased reload time, temporary jam).
+- [x] UI: Display basic typing stats (accuracy, WPM) in HUD.
 
 ### Letter Pool Progression
 

--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -63,6 +63,8 @@ type Game struct {
 	unlockStage int
 
 	lastUpdate time.Time
+
+	typing TypingStats
 }
 
 // NewGame creates a new instance of the Game.
@@ -93,6 +95,7 @@ func NewGameWithConfig(cfg Config) *Game {
 		projectiles: make([]*Projectile, 0),
 		letterPool:  make([]rune, 0),
 		unlockStage: 0,
+		typing:      NewTypingStats(),
 	}
 
 	tx, ty := tilePosition(1, 16)

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -87,6 +87,9 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 			lines = append(lines, fmt.Sprintf("Base HP: %d", h.game.base.Health()))
 		}
 		lines = append(lines, fmt.Sprintf("Wave %d | Gold %d | Mobs %d", h.game.currentWave, h.game.gold, len(h.game.mobs)))
+		acc := h.game.typing.Accuracy() * 100
+		wpm := h.game.typing.WPM()
+		lines = append(lines, fmt.Sprintf("Accuracy: %.0f%% | WPM: %.1f", acc, wpm))
 	}
 
 	if len(lines) == 0 {

--- a/v1/internal/game/tower.go
+++ b/v1/internal/game/tower.go
@@ -189,9 +189,15 @@ func (t *Tower) Update(dt float64) {
 						break
 					}
 				}
+				if t.game != nil {
+					t.game.typing.Record(true)
+				}
 				break
 			} else if len(t.reloadQueue) > 0 {
 				// Wrong letter - jam the tower
+				if t.game != nil {
+					t.game.typing.Record(false)
+				}
 				t.jammed = true
 				t.jammedLetter = t.reloadQueue[0] // preserve current letter
 				break
@@ -279,7 +285,11 @@ func (t *Tower) Update(dt float64) {
 
 	// Set cooldown only if we actually fired
 	if shotsFired > 0 {
-		t.cooldown = t.rate
+		mult := 1.0
+		if t.game != nil {
+			mult = t.game.typing.RateMultiplier()
+		}
+		t.cooldown = t.rate * mult
 	}
 }
 

--- a/v1/internal/game/typing_stats.go
+++ b/v1/internal/game/typing_stats.go
@@ -1,0 +1,60 @@
+package game
+
+import "time"
+
+// TypingStats tracks typing performance metrics.
+type TypingStats struct {
+	start     time.Time
+	correct   int
+	incorrect int
+}
+
+// NewTypingStats initializes a TypingStats value.
+func NewTypingStats() TypingStats {
+	return TypingStats{start: time.Now()}
+}
+
+// Record updates the stats with whether a typed letter was correct.
+func (ts *TypingStats) Record(correct bool) {
+	if correct {
+		ts.correct++
+	} else {
+		ts.incorrect++
+	}
+}
+
+// Total returns the total number of recorded letters.
+func (ts *TypingStats) Total() int {
+	return ts.correct + ts.incorrect
+}
+
+// Accuracy returns typing accuracy as a fraction between 0 and 1.
+func (ts *TypingStats) Accuracy() float64 {
+	total := ts.Total()
+	if total == 0 {
+		return 1
+	}
+	return float64(ts.correct) / float64(total)
+}
+
+// WPM returns words per minute using a 5 chars per word estimate.
+func (ts *TypingStats) WPM() float64 {
+	mins := time.Since(ts.start).Minutes()
+	if mins <= 0 {
+		return 0
+	}
+	return (float64(ts.Total()) / 5.0) / mins
+}
+
+// RateMultiplier returns a fire rate multiplier based on typing performance.
+func (ts *TypingStats) RateMultiplier() float64 {
+	acc := ts.Accuracy()
+	wpm := ts.WPM()
+	if wpm >= 40 && acc >= 0.9 {
+		return 0.9
+	}
+	if wpm < 20 || acc < 0.6 {
+		return 1.2
+	}
+	return 1.0
+}

--- a/v1/internal/game/typing_stats_test.go
+++ b/v1/internal/game/typing_stats_test.go
@@ -1,0 +1,21 @@
+package game
+
+import "testing"
+
+func TestTypingStatsBasic(t *testing.T) {
+	ts := NewTypingStats()
+	ts.Record(true)
+	ts.Record(false)
+	ts.Record(true)
+	if ts.Total() != 3 {
+		t.Fatalf("expected total 3 got %d", ts.Total())
+	}
+	acc := ts.Accuracy()
+	if acc <= 0.66 || acc >= 1 {
+		t.Errorf("unexpected accuracy %.2f", acc)
+	}
+	if ts.WPM() < 0 {
+		t.Errorf("wpm should not be negative")
+	}
+	_ = ts.RateMultiplier()
+}


### PR DESCRIPTION
## Summary
- track reload typing speed and accuracy via new `TypingStats`
- apply rate bonuses or penalties based on typing performance
- show accuracy and WPM in the HUD
- document typing stats feature and update TODO checklist
- basic tests for TypingStats

## Testing
- `go vet ./...` *(fails: unable to download dependencies)*
- `go test ./...` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840a11ac1748327aca4e26f00025c98