### PR TITLE
Implement pause menu and basic settings

### DIFF
--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -1,10 +1,12 @@
 package game
 
 import (
+	"encoding/json"
 	"fmt"
 	"image/color"
 	"math"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -36,6 +38,23 @@ var letterUnlockSequence = [][]rune{
 	{'c', 'm'}, // bottom row center
 	{'v', 'n'}, // bottom row index
 	{'x', 'z'}, // bottom row outside
+}
+
+type savedTower struct {
+	X            float64
+	Y            float64
+	Damage       int
+	Range        float64
+	Rate         float64
+	AmmoCapacity int
+}
+
+type savedGame struct {
+	Gold     int
+	Wave     int
+	BaseHP   int
+	Towers   []savedTower
+	Settings Settings
 }
 
 // Game represents the game state and implements ebiten.Game interface.
@@ -72,6 +91,13 @@ type Game struct {
 	lastUpdate time.Time
 
 	typing TypingStats
+
+	pauseCursor    int
+	settingsOpen   bool
+	settingsCursor int
+
+	sound    *SoundManager
+	settings Settings
 }
 
 // NewGame creates a new instance of the Game.
@@ -107,6 +133,8 @@ func NewGameWithConfig(cfg Config) *Game {
 		typing:      NewTypingStats(),
 		cursorX:     2,
 		cursorY:     16,
+		sound:       NewSoundManager(),
+		settings:    DefaultSettings(),
 	}
 
 	tx, ty := tilePosition(1, 16)
@@ -174,8 +202,20 @@ func (g *Game) Update() error {
 		}
 	}
 
-	if g.input.Space() {
+	if g.input.Save() {
+		g.saveGame("savegame.json")
+	}
+	if g.input.Load() {
+		if err := g.loadGame("savegame.json"); err != nil {
+			fmt.Println("load game:", err)
+		}
+	}
+
+	if g.input.Space() && !g.settingsOpen {
 		g.paused = !g.paused
+		if g.paused {
+			g.pauseCursor = 0
+		}
 	}
 
 	if g.input.Quit() {
@@ -183,6 +223,46 @@ func (g *Game) Update() error {
 	}
 
 	if g.paused {
+		if g.settingsOpen {
+			if g.input.Down() {
+				g.settingsCursor = (g.settingsCursor + 1) % 2
+			}
+			if g.input.Up() {
+				g.settingsCursor = (g.settingsCursor - 1 + 2) % 2
+			}
+			if g.input.Enter() {
+				switch g.settingsCursor {
+				case 0:
+					g.settings.Mute = !g.settings.Mute
+					if g.sound != nil {
+						g.sound.ToggleMute()
+					}
+				case 1:
+					g.settingsOpen = false
+				}
+			}
+		} else {
+			const optionsCount = 4
+			if g.input.Down() {
+				g.pauseCursor = (g.pauseCursor + 1) % optionsCount
+			}
+			if g.input.Up() {
+				g.pauseCursor = (g.pauseCursor - 1 + optionsCount) % optionsCount
+			}
+			if g.input.Enter() {
+				switch g.pauseCursor {
+				case 0:
+					g.paused = false
+				case 1:
+					g.Restart()
+				case 2:
+					return ebiten.Termination
+				case 3:
+					g.settingsOpen = true
+					g.settingsCursor = 0
+				}
+			}
+		}
 		return nil
 	}
 
@@ -392,10 +472,36 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	}
 
 	if g.paused {
-		opts := &text.DrawOptions{}
-		opts.GeoM.Translate(900, 520)
-		opts.ColorScale.ScaleWithColor(color.White)
-		text.Draw(g.screen, "-- PAUSED --", BoldFont, opts)
+		var lines []string
+		if g.settingsOpen {
+			lines = append(lines, "-- SETTINGS --")
+			mute := "Off"
+			if g.settings.Mute {
+				mute = "On"
+			}
+			options := []string{
+				"Toggle Mute: " + mute,
+				"Back",
+			}
+			for i, opt := range options {
+				prefix := "  "
+				if i == g.settingsCursor {
+					prefix = "> "
+				}
+				lines = append(lines, prefix+opt)
+			}
+		} else {
+			lines = append(lines, "-- PAUSED --")
+			opts := []string{"Resume", "Restart", "Quit", "Settings"}
+			for i, opt := range opts {
+				prefix := "  "
+				if i == g.pauseCursor {
+					prefix = "> "
+				}
+				lines = append(lines, prefix+opt)
+			}
+		}
+		drawMenu(g.screen, lines, 860, 480)
 		g.renderFrame(screen)
 		return
 	}
@@ -704,4 +810,65 @@ func (g *Game) reloadConfig(path string) error {
 	}
 	g.mobsToSpawn = base + cfg.MobsPerWaveInc*(g.currentWave-1)
 	return nil
+}
+
+func (g *Game) saveGame(path string) {
+	sg := savedGame{
+		Gold:     g.gold,
+		Wave:     g.currentWave,
+		BaseHP:   g.base.Health(),
+		Settings: g.settings,
+	}
+	for _, t := range g.towers {
+		sg.Towers = append(sg.Towers, savedTower{
+			X:            t.pos.X,
+			Y:            t.pos.Y,
+			Damage:       t.damage,
+			Range:        t.rangeDst,
+			Rate:         t.rate,
+			AmmoCapacity: t.ammoCapacity,
+		})
+	}
+	b, err := json.MarshalIndent(sg, "", "  ")
+	if err == nil {
+		_ = os.WriteFile(path, b, 0644)
+	}
+}
+
+func (g *Game) loadGame(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var sg savedGame
+	if err := json.Unmarshal(data, &sg); err != nil {
+		return err
+	}
+	*g = *NewGameWithConfig(*g.cfg)
+	g.gold = sg.Gold
+	g.currentWave = sg.Wave
+	g.base.health = sg.BaseHP
+	g.settings = sg.Settings
+	if g.sound != nil && g.settings.Mute {
+		g.sound.mute = true
+	}
+	g.towers = nil
+	for _, st := range sg.Towers {
+		t := NewTower(g, st.X, st.Y)
+		t.damage = st.Damage
+		t.rangeDst = st.Range
+		t.rangeImg = generateRangeImage(t.rangeDst)
+		t.rate = st.Rate
+		t.ammoCapacity = st.AmmoCapacity
+		t.ammoQueue = make([]bool, t.ammoCapacity)
+		for i := range t.ammoQueue {
+			t.ammoQueue[i] = true
+		}
+		g.towers = append(g.towers, t)
+	}
+	return nil
+}
+
+func (g *Game) Restart() {
+	*g = *NewGameWithConfig(*g.cfg)
 }

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -147,3 +147,33 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 		currentY += lineHeight
 	}
 }
+
+// drawMenu renders a simple vertical list of lines with a background box.
+func drawMenu(screen *ebiten.Image, lines []string, textX, initialY int) {
+	if len(lines) == 0 {
+		return
+	}
+	lineHeight := 18
+	padding := 5.0
+
+	bgX := float64(textX) - padding
+	bgY := float64(initialY) - padding
+	bgWidth := 320.0
+	for _, line := range lines {
+		w := float64(len(line)) * 13.0
+		if w+padding*2 > bgWidth {
+			bgWidth = w + padding*2
+		}
+	}
+	bgHeight := float64(len(lines)*lineHeight) + (padding * 2.0) + 18.0
+	vector.DrawFilledRect(screen, float32(bgX), float32(bgY), float32(bgWidth), float32(bgHeight), color.RGBA{0, 0, 0, 180}, false)
+
+	currentY := initialY
+	for _, line := range lines {
+		opts := &text.DrawOptions{}
+		opts.GeoM.Translate(float64(textX), float64(currentY))
+		opts.ColorScale.ScaleWithColor(color.White)
+		text.Draw(screen, line, NormalFont, opts)
+		currentY += lineHeight
+	}
+}

--- a/v1/internal/game/input.go
+++ b/v1/internal/game/input.go
@@ -21,6 +21,8 @@ type InputHandler interface {
 	Up() bool
 	Down() bool
 	Build() bool
+	Save() bool
+	Load() bool
 }
 
 type Input struct {
@@ -35,7 +37,8 @@ type Input struct {
 	up        bool
 	down      bool
 	build     bool
-
+	save      bool
+	load      bool
 }
 
 // NewInput creates a new Input instance with default values.
@@ -52,7 +55,8 @@ func NewInput() *Input {
 		up:        false,
 		down:      false,
 		build:     false,
-
+		save:      false,
+		load:      false,
 	}
 }
 
@@ -65,6 +69,8 @@ func (i *Input) Update() {
 	i.backspace = inpututil.IsKeyJustPressed(ebiten.KeyBackspace)
 	i.space = inpututil.IsKeyJustPressed(ebiten.KeySpace)
 	i.reload = inpututil.IsKeyJustPressed(ebiten.KeyF5)
+	i.save = inpututil.IsKeyJustPressed(ebiten.KeyF2)
+	i.load = inpututil.IsKeyJustPressed(ebiten.KeyF3)
 	i.enter = inpututil.IsKeyJustPressed(ebiten.KeyEnter)
 
 	i.left = inpututil.IsKeyJustPressed(ebiten.KeyH) || inpututil.IsKeyJustPressed(ebiten.KeyArrowLeft)
@@ -87,6 +93,8 @@ func (i *Input) Reset() {
 	i.up = false
 	i.down = false
 	i.build = false
+	i.save = false
+	i.load = false
 }
 
 // Quit returns whether the game should quit.
@@ -124,3 +132,5 @@ func (i *Input) Right() bool { return i.right }
 func (i *Input) Up() bool    { return i.up }
 func (i *Input) Down() bool  { return i.down }
 func (i *Input) Build() bool { return i.build }
+func (i *Input) Save() bool  { return i.save }
+func (i *Input) Load() bool  { return i.load }

--- a/v1/internal/game/settings.go
+++ b/v1/internal/game/settings.go
@@ -1,0 +1,11 @@
+package game
+
+// Settings holds user configurable options.
+type Settings struct {
+	Mute bool `json:"mute"`
+}
+
+// DefaultSettings returns a Settings struct with defaults.
+func DefaultSettings() Settings {
+	return Settings{Mute: false}
+}

--- a/v1/internal/game/sound.go
+++ b/v1/internal/game/sound.go
@@ -1,0 +1,48 @@
+package game
+
+import (
+	"bytes"
+	"math"
+
+	"github.com/hajimehoshi/ebiten/v2/audio"
+)
+
+const sampleRate = 22050
+
+// SoundManager handles basic sound effects and music.
+type SoundManager struct {
+	ctx  *audio.Context
+	mute bool
+}
+
+// NewSoundManager creates a SoundManager with an audio context.
+func NewSoundManager() *SoundManager {
+	ctx := audio.NewContext(sampleRate)
+	return &SoundManager{ctx: ctx}
+}
+
+// ToggleMute enables or disables all sound output.
+func (s *SoundManager) ToggleMute() { s.mute = !s.mute }
+
+// PlayBeep plays a short beep sound if not muted.
+func (s *SoundManager) PlayBeep() {
+	if s == nil || s.mute {
+		return
+	}
+	buf := generateSineWave(440, 0.1)
+	p := audio.NewPlayerFromBytes(s.ctx, buf)
+	p.Play()
+}
+
+// generateSineWave returns raw PCM data for a sine wave.
+func generateSineWave(freq float64, dur float64) []byte {
+	length := int(float64(sampleRate) * dur)
+	buf := bytes.NewBuffer(make([]byte, 0, length*2))
+	for i := 0; i < length; i++ {
+		v := math.Sin(2 * math.Pi * freq * float64(i) / float64(sampleRate))
+		sample := int16(v * 0.3 * math.MaxInt16)
+		buf.WriteByte(byte(sample))
+		buf.WriteByte(byte(sample >> 8))
+	}
+	return buf.Bytes()
+}

--- a/v1/internal/game/tower.go
+++ b/v1/internal/game/tower.go
@@ -290,6 +290,9 @@ func (t *Tower) Update(dt float64) {
 		mult := 1.0
 		if t.game != nil {
 			mult = t.game.typing.RateMultiplier()
+			if t.game.sound != nil {
+				t.game.sound.PlayBeep()
+			}
 		}
 		t.cooldown = t.rate * mult
 	}


### PR DESCRIPTION
## Summary
- add simple sound manager and settings structs
- implement pause menu and settings menu navigation
- support saving/loading game data
- play beep sound when towers fire

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840a41439588327951a6d94013165e2