### PR TITLE
Add selectable tower types

### DIFF
--- a/v1/internal/game/build_test.go
+++ b/v1/internal/game/build_test.go
@@ -10,11 +10,14 @@ func TestBuildTowerCostsGold(t *testing.T) {
 	g.cursorX = 4
 	g.cursorY = 4
 	initial := len(g.towers)
-	g.buildTowerAtCursor()
+	g.buildTowerAtCursorType(TowerSniper)
 	if len(g.towers) != initial+1 {
 		t.Fatalf("expected tower count %d got %d", initial+1, len(g.towers))
 	}
 	if g.gold != 5 {
 		t.Fatalf("expected gold 5 got %d", g.gold)
+	}
+	if g.towers[0].towerType != TowerSniper {
+		t.Fatalf("expected sniper tower type")
 	}
 }

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -53,6 +53,30 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 			}
 			lines = append(lines, prefix+opt)
 		}
+	} else if h.game.buildMenuOpen {
+		cost := h.game.cfg.TowerConstructionCost
+		if cost == 0 {
+			cost = DefaultConfig.TowerConstructionCost
+		}
+		lines = append(lines, "-- BUILD --")
+		lines = append(lines, fmt.Sprintf("Gold: %d", h.game.gold))
+		options := []string{
+			"[1] Basic Tower",
+			"[2] Sniper Tower",
+			"[3] Rapid Tower",
+			"Cancel",
+		}
+		for i, opt := range options {
+			prefix := "  "
+			if i == h.game.buildCursor {
+				prefix = "> "
+			}
+			if i < 3 {
+				lines = append(lines, fmt.Sprintf("%s%s (%d gold)", prefix, opt, cost))
+			} else {
+				lines = append(lines, prefix+opt)
+			}
+		}
 	} else {
 		if len(h.game.towers) > 0 {
 			t := h.game.towers[h.game.selectedTower]

--- a/v1/internal/game/tower.go
+++ b/v1/internal/game/tower.go
@@ -9,6 +9,15 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
+// TowerType represents the variety of tower with unique stats.
+type TowerType int
+
+const (
+	TowerBasic TowerType = iota
+	TowerSniper
+	TowerRapid
+)
+
 // Tower represents a stationary auto-firing tower.
 type Tower struct {
 	BaseEntity
@@ -17,6 +26,9 @@ type Tower struct {
 	rangeDst float64
 	game     *Game
 	rangeImg *ebiten.Image
+
+	// Type of tower (basic, sniper, rapid-fire)
+	towerType TowerType
 
 	// Two-queue ammo system
 	ammoQueue    []bool // ready-to-fire ammunition (true = loaded, false = empty)
@@ -40,13 +52,23 @@ type Tower struct {
 	damageBonus     int
 }
 
-// NewTower creates a new Tower at the given position.
+// NewTower creates a basic tower at the given position.
 func NewTower(g *Game, x, y float64) *Tower {
-	return NewTowerWithLevel(g, x, y, 1)
+	return NewTowerWithTypeAndLevel(g, x, y, TowerBasic, 1)
 }
 
-// NewTowerWithLevel creates a new Tower at the given position and level.
+// NewTowerWithLevel creates a basic Tower at the given position and level.
 func NewTowerWithLevel(g *Game, x, y float64, level int) *Tower {
+	return NewTowerWithTypeAndLevel(g, x, y, TowerBasic, level)
+}
+
+// NewTowerWithType creates a tower of the specified type at the given position.
+func NewTowerWithType(g *Game, x, y float64, tt TowerType) *Tower {
+	return NewTowerWithTypeAndLevel(g, x, y, tt, 1)
+}
+
+// NewTowerWithTypeAndLevel creates a tower of the specified type and level.
+func NewTowerWithTypeAndLevel(g *Game, x, y float64, tt TowerType, level int) *Tower {
 	if level < 1 {
 		level = 1
 	}
@@ -75,6 +97,23 @@ func NewTowerWithLevel(g *Game, x, y float64, level int) *Tower {
 		jammed:       false,
 		foresight:    5,
 		damageBonus:  0,
+		towerType:    tt,
+	}
+
+	// Apply base stats based on tower type
+	switch tt {
+	case TowerSniper:
+		t.damage *= 3
+		t.rangeDst *= 1.5
+		t.rate *= 2
+		t.ammoCapacity = 3
+	case TowerRapid:
+		if t.damage > 1 {
+			t.damage /= 2
+		}
+		t.rangeDst *= 0.7
+		t.rate *= 0.5
+		t.ammoCapacity = 6
 	}
 
 	t.applyLevel()

--- a/v1/internal/game/tower_test.go
+++ b/v1/internal/game/tower_test.go
@@ -236,3 +236,18 @@ func TestSingleUpgradePurchase(t *testing.T) {
 		t.Errorf("gold should not change with insufficient funds, changed from %d to %d", oldGold, g.gold)
 	}
 }
+
+func TestNewTowerTypes(t *testing.T) {
+	g := &Game{cfg: &DefaultConfig}
+	sniper := NewTowerWithType(g, 0, 0, TowerSniper)
+	rapid := NewTowerWithType(g, 0, 0, TowerRapid)
+	if sniper.towerType != TowerSniper || rapid.towerType != TowerRapid {
+		t.Fatalf("tower types not set correctly")
+	}
+	if sniper.rangeDst <= rapid.rangeDst {
+		t.Errorf("sniper should have longer range")
+	}
+	if rapid.rate >= sniper.rate {
+		t.Errorf("rapid tower should fire faster")
+	}
+}


### PR DESCRIPTION
## Summary
- add `TowerType` enum and fields
- create `NewTowerWithType` and assign default stats by type
- support build menu for choosing tower type
- draw build menu in HUD
- test tower type creation

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840ac0f2e608327ae831edc84d7b9b2