### PR TITLE
Implement performance tracking features

### DIFF
--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -70,6 +70,10 @@ type Game struct {
 	achievements []string
 	towerMods    TowerModifiers
 
+	score           int
+	gameOverHandled bool
+	history         *PerformanceHistory
+
 	cursorX int
 	cursorY int
 
@@ -92,36 +96,44 @@ func NewGame() *Game {
 
 // NewGameWithConfig creates a new instance of the Game using the provided configuration.
 func NewGameWithConfig(cfg Config) *Game {
+	return NewGameWithHistory(cfg, &PerformanceHistory{})
+}
+
+// NewGameWithHistory allows supplying an existing performance history when creating a game.
+func NewGameWithHistory(cfg Config, hist *PerformanceHistory) *Game {
 	ebiten.SetWindowTitle("TypingTowers")
 	ebiten.SetWindowSize(1920/8, 1080/8)
 	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 	// ebiten.SetFullscreen(true)
 
 	g := &Game{
-		screen:        ebiten.NewImage(1920, 1080),
-		input:         NewInput(),
-		paused:        false,
-		gold:          0,
-		shopOpen:      false,
-		selectedTower: 0,
-		shopCursor:    0,
-		currentWave:   1,
-		spawnInterval: cfg.SpawnInterval, // already in seconds
-		spawnTicker:   0,
-		mobsToSpawn:   cfg.MobsPerWave,
-		cfg:           &cfg,
-		mobs:         make([]*Mob, 0),
-		projectiles:  make([]*Projectile, 0),
-		letterPool:   make([]rune, 0),
-		unlockStage:  0,
-		techTree:     DefaultTechTree(),
-		achievements: make([]string, 0),
-		towerMods:    TowerModifiers{DamageMult: 1, RangeMult: 1, FireRateMult: 1},
-		typing:       NewTypingStats(),
-		cursorX:      2,
-		cursorY:      16,
-		sound:       NewSoundManager(),
-		settings:    DefaultSettings(),
+		screen:          ebiten.NewImage(1920, 1080),
+		input:           NewInput(),
+		paused:          false,
+		gold:            0,
+		shopOpen:        false,
+		selectedTower:   0,
+		shopCursor:      0,
+		currentWave:     1,
+		spawnInterval:   cfg.SpawnInterval, // already in seconds
+		spawnTicker:     0,
+		mobsToSpawn:     cfg.MobsPerWave,
+		cfg:             &cfg,
+		mobs:            make([]*Mob, 0),
+		projectiles:     make([]*Projectile, 0),
+		letterPool:      make([]rune, 0),
+		unlockStage:     0,
+		techTree:        DefaultTechTree(),
+		achievements:    make([]string, 0),
+		towerMods:       TowerModifiers{DamageMult: 1, RangeMult: 1, FireRateMult: 1},
+		typing:          NewTypingStats(),
+		history:         hist,
+		score:           0,
+		gameOverHandled: false,
+		cursorX:         2,
+		cursorY:         16,
+		sound:           NewSoundManager(),
+		settings:        DefaultSettings(),
 	}
 
 	tx, ty := tilePosition(1, 16)
@@ -397,7 +409,13 @@ func (g *Game) Update() error {
 		}
 		if !m.alive {
 			g.mobs = append(g.mobs[:i], g.mobs[i+1:]...)
-			g.gold++
+			mult := g.typing.ScoreMultiplier()
+			reward := int(mult)
+			if reward < 1 {
+				reward = 1
+			}
+			g.gold += reward
+			g.score += reward
 			continue
 		}
 		i++
@@ -405,6 +423,14 @@ func (g *Game) Update() error {
 
 	if !g.base.Alive() {
 		g.gameOver = true
+	}
+
+	if g.gameOver && !g.gameOverHandled {
+		if g.history != nil {
+			g.history.Record(g.typing)
+		}
+		g.evaluatePerformanceAchievements()
+		g.gameOverHandled = true
 	}
 
 	return nil
@@ -420,6 +446,23 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		opts.GeoM.Translate(900, 540)
 		opts.ColorScale.ScaleWithColor(color.White)
 		text.Draw(g.screen, "Game Over", BoldFont, opts)
+		summary := []string{
+			fmt.Sprintf("Score: %d", g.score),
+			fmt.Sprintf("Accuracy: %.0f%%", g.typing.Accuracy()*100),
+			fmt.Sprintf("WPM: %.1f", g.typing.WPM()),
+		}
+		if g.history != nil {
+			summary = append(summary,
+				fmt.Sprintf("Best Accuracy: %.0f%%", g.history.BestAccuracy*100),
+				fmt.Sprintf("Best WPM: %.1f", g.history.BestWPM))
+		}
+		if len(g.achievements) > 0 {
+			summary = append(summary, "Achievements:")
+			for _, a := range g.achievements {
+				summary = append(summary, " - "+a)
+			}
+		}
+		drawMenu(g.screen, summary, 820, 580)
 		g.renderFrame(screen)
 		return
 	}
@@ -861,5 +904,34 @@ func (g *Game) loadGame(path string) error {
 }
 
 func (g *Game) Restart() {
-	*g = *NewGameWithConfig(*g.cfg)
+	hist := g.history
+	*g = *NewGameWithHistory(*g.cfg, hist)
+}
+
+// evaluatePerformanceAchievements awards achievements and gold based on typing performance.
+func (g *Game) evaluatePerformanceAchievements() {
+	wpm := g.typing.WPM()
+	acc := g.typing.Accuracy()
+
+	add := func(name string) {
+		for _, a := range g.achievements {
+			if a == name {
+				return
+			}
+		}
+		g.achievements = append(g.achievements, name)
+	}
+
+	if wpm >= 60 {
+		add("Speed Demon")
+		g.gold += 5
+	}
+	if acc >= 0.95 {
+		add("Sharpshooter")
+		g.gold += 5
+	}
+	if g.typing.MaxCombo() >= 10 {
+		add("Combo Master")
+		g.gold += 5
+	}
 }

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -103,7 +103,7 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 		if h.game.base != nil {
 			lines = append(lines, fmt.Sprintf("Base HP: %d", h.game.base.Health()))
 		}
-		lines = append(lines, fmt.Sprintf("Wave %d | Gold %d | Mobs %d", h.game.currentWave, h.game.gold, len(h.game.mobs)))
+		lines = append(lines, fmt.Sprintf("Wave %d | Gold %d | Score %d | Mobs %d", h.game.currentWave, h.game.gold, h.game.score, len(h.game.mobs)))
 		acc := h.game.typing.Accuracy() * 100
 		wpm := h.game.typing.WPM()
 		lines = append(lines, fmt.Sprintf("Accuracy: %.0f%% | WPM: %.1f", acc, wpm))

--- a/v1/internal/game/performance.go
+++ b/v1/internal/game/performance.go
@@ -1,0 +1,26 @@
+package game
+
+// Performance represents a single game's typing performance metrics.
+type Performance struct {
+	WPM      float64
+	Accuracy float64
+}
+
+// PerformanceHistory tracks best stats and historical records.
+type PerformanceHistory struct {
+	BestWPM      float64
+	BestAccuracy float64
+	Records      []Performance
+}
+
+// Record adds a new performance entry and updates best metrics.
+func (ph *PerformanceHistory) Record(ts TypingStats) {
+	p := Performance{WPM: ts.WPM(), Accuracy: ts.Accuracy()}
+	ph.Records = append(ph.Records, p)
+	if p.WPM > ph.BestWPM {
+		ph.BestWPM = p.WPM
+	}
+	if p.Accuracy > ph.BestAccuracy {
+		ph.BestAccuracy = p.Accuracy
+	}
+}

--- a/v1/internal/game/typing_stats.go
+++ b/v1/internal/game/typing_stats.go
@@ -75,3 +75,21 @@ func (ts *TypingStats) RateMultiplier() float64 {
 	}
 	return mult
 }
+
+// ScoreMultiplier returns a multiplier for score/gold rewards based on typing
+// performance. Higher WPM and accuracy grant better rewards while poor
+// performance reduces them.
+func (ts *TypingStats) ScoreMultiplier() float64 {
+	acc := ts.Accuracy()
+	wpm := ts.WPM()
+	switch {
+	case wpm >= 60 && acc >= 0.95:
+		return 2.0
+	case wpm >= 40 && acc >= 0.9:
+		return 1.5
+	case wpm < 20 || acc < 0.6:
+		return 0.5
+	default:
+		return 1.0
+	}
+}

--- a/v1/internal/game/typing_stats_test.go
+++ b/v1/internal/game/typing_stats_test.go
@@ -1,6 +1,9 @@
 package game
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestTypingStatsBasic(t *testing.T) {
 	ts := NewTypingStats()
@@ -34,5 +37,22 @@ func TestTypingStatsCombo(t *testing.T) {
 	}
 	if ts.MaxCombo() < 3 {
 		t.Errorf("max combo should be at least 3")
+	}
+}
+
+func TestScoreMultiplierAndHistory(t *testing.T) {
+	ts := NewTypingStats()
+	ts.start = ts.start.Add(-time.Minute)
+	for i := 0; i < 50; i++ {
+		ts.Record(true)
+	}
+	if ts.ScoreMultiplier() <= 1 {
+		t.Errorf("expected multiplier > 1 for good performance")
+	}
+
+	hist := PerformanceHistory{}
+	hist.Record(ts)
+	if hist.BestWPM <= 0 || hist.BestAccuracy <= 0 {
+		t.Errorf("history not updated")
 	}
 }


### PR DESCRIPTION
## Summary
- add scoring multiplier based on typing performance
- keep history of best WPM and accuracy
- reward players with achievements on great typing stats
- display score and final summary screen
- test coverage for new functionality

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840ac3061c483279aa0cbea0270de69