### PR TITLE
Implement shared queue manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ go test ./...
 
 -## Current prototype
 
-- Global FIFO queue, single Farmer + Barracks building (f j words). Barracks words spawn Footman units.
+ - Shared FIFO queue manager implemented. Farmer and Barracks enqueue words (f j pool) that must be typed in order. Completing a Barracks word spawns a Footman.
 - Basic orc grunt waves scale every 45 s.
 - Typing speed/accuracy multiplier working.
 - Vim navigation for pause/menu/shop implemented.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,10 +25,10 @@
   - [x] Barracks cooldown logic
   - [x] Barracks word generation from letter pool
   - [x] Unit spawn on word completion
-- [ ] **P-003** Shared queue manager
-  - [ ] Global FIFO queue structure
-  - [ ] Enqueue from multiple buildings
-  - [ ] Dequeue and typing validation
+- [x] **P-003** Shared queue manager
+  - [x] Global FIFO queue structure
+  - [x] Enqueue from multiple buildings
+  - [x] Dequeue and typing validation
 - [ ] **P-004** Per-building cooldown timers
   - [ ] Timer tick/update logic
   - [ ] Cooldown reset on word completion

--- a/v1/internal/game/barracks.go
+++ b/v1/internal/game/barracks.go
@@ -9,9 +9,10 @@ type Barracks struct {
 	letterPool  []rune  // available letters for word generation
 	wordLenMin  int
 	wordLenMax  int
-	lastWord    string // last generated word (for testing/debug)
-	pendingWord string // word currently in queue (if any)
-	active      bool   // is the Barracks running?
+	lastWord    string        // last generated word (for testing/debug)
+	pendingWord string        // word currently in queue (if any)
+	active      bool          // is the Barracks running?
+	queue       *QueueManager // optional global queue manager
 }
 
 // NewBarracks creates a new Barracks with default settings.
@@ -23,6 +24,7 @@ func NewBarracks() *Barracks {
 		wordLenMin: 2,
 		wordLenMax: 3,
 		active:     true,
+		queue:      nil,
 	}
 }
 
@@ -35,6 +37,9 @@ func (b *Barracks) Update(dt float64) string {
 	if b.cooldown <= 0 {
 		word := b.generateWord()
 		b.pendingWord = word
+		if b.queue != nil {
+			b.queue.Enqueue(Word{Text: word, Source: "Barracks"})
+		}
 		b.cooldown = b.interval
 		return word
 	}
@@ -69,3 +74,6 @@ func (b *Barracks) SetLetterPool(pool []rune) { b.letterPool = pool }
 
 // SetActive enables or disables the Barracks.
 func (b *Barracks) SetActive(active bool) { b.active = active }
+
+// SetQueue assigns a QueueManager for global word management.
+func (b *Barracks) SetQueue(q *QueueManager) { b.queue = q }

--- a/v1/internal/game/farmer.go
+++ b/v1/internal/game/farmer.go
@@ -11,10 +11,11 @@ type Farmer struct {
 	letterPool  []rune  // available letters for word generation
 	wordLenMin  int
 	wordLenMax  int
-	lastWord    string // last generated word (for testing/debug)
-	pendingWord string // word currently in queue (if any)
-	resourceOut int    // amount of Food to output per completion
-	active      bool   // is the Farmer running?
+	lastWord    string        // last generated word (for testing/debug)
+	pendingWord string        // word currently in queue (if any)
+	resourceOut int           // amount of Food to output per completion
+	active      bool          // is the Farmer running?
+	queue       *QueueManager // optional global queue manager
 }
 
 // NewFarmer creates a new Farmer with default settings.
@@ -27,6 +28,7 @@ func NewFarmer() *Farmer {
 		wordLenMax:  3,
 		resourceOut: 1,
 		active:      true,
+		queue:       nil,
 	}
 }
 
@@ -40,6 +42,9 @@ func (f *Farmer) Update(dt float64) string {
 	if f.cooldown <= 0 {
 		word := f.generateWord()
 		f.pendingWord = word
+		if f.queue != nil {
+			f.queue.Enqueue(Word{Text: word, Source: "Farmer"})
+		}
 		f.cooldown = f.interval
 		return word
 	}
@@ -79,3 +84,6 @@ func (f *Farmer) SetLetterPool(pool []rune) {
 func (f *Farmer) SetActive(active bool) {
 	f.active = active
 }
+
+// SetQueue assigns a QueueManager for global word management.
+func (f *Farmer) SetQueue(q *QueueManager) { f.queue = q }

--- a/v1/internal/game/queue.go
+++ b/v1/internal/game/queue.go
@@ -1,0 +1,47 @@
+package game
+
+// Word represents a queued typing challenge produced by a building.
+type Word struct {
+	Text   string // text the player must type
+	Source string // name of the building that generated the word
+}
+
+// QueueManager maintains a global FIFO queue of words.
+type QueueManager struct {
+	queue []Word
+}
+
+// NewQueueManager initializes an empty queue.
+func NewQueueManager() *QueueManager {
+	return &QueueManager{queue: make([]Word, 0)}
+}
+
+// Enqueue adds a word to the end of the queue.
+func (q *QueueManager) Enqueue(w Word) {
+	q.queue = append(q.queue, w)
+}
+
+// Len returns the number of words currently in the queue.
+func (q *QueueManager) Len() int { return len(q.queue) }
+
+// Peek returns the first word without removing it. ok is false if the queue is empty.
+func (q *QueueManager) Peek() (w Word, ok bool) {
+	if len(q.queue) == 0 {
+		return Word{}, false
+	}
+	return q.queue[0], true
+}
+
+// TryDequeue compares input with the first word. If they match, the word is removed
+// and returned with ok=true. Otherwise the queue is unchanged and ok=false.
+func (q *QueueManager) TryDequeue(input string) (Word, bool) {
+	if len(q.queue) == 0 {
+		return Word{}, false
+	}
+	if q.queue[0].Text == input {
+		w := q.queue[0]
+		q.queue = q.queue[1:]
+		return w, true
+	}
+	return Word{}, false
+}

--- a/v1/internal/game/queue_test.go
+++ b/v1/internal/game/queue_test.go
@@ -1,0 +1,54 @@
+package game
+
+import "testing"
+
+func TestQueueFIFO(t *testing.T) {
+	q := NewQueueManager()
+	q.Enqueue(Word{Text: "one", Source: "farmer"})
+	q.Enqueue(Word{Text: "two", Source: "barracks"})
+
+	if q.Len() != 2 {
+		t.Fatalf("expected queue length 2 got %d", q.Len())
+	}
+	w, ok := q.Peek()
+	if !ok || w.Text != "one" || w.Source != "farmer" {
+		t.Fatalf("unexpected first word: %+v ok=%v", w, ok)
+	}
+}
+
+func TestQueueDequeueValidation(t *testing.T) {
+	q := NewQueueManager()
+	q.Enqueue(Word{Text: "alpha", Source: "farmer"})
+
+	if _, ok := q.TryDequeue("beta"); ok {
+		t.Fatalf("dequeue should fail for wrong input")
+	}
+	if q.Len() != 1 {
+		t.Fatalf("queue length changed on failed dequeue")
+	}
+	w, ok := q.TryDequeue("alpha")
+	if !ok || w.Text != "alpha" {
+		t.Fatalf("dequeue failed for correct input")
+	}
+	if q.Len() != 0 {
+		t.Fatalf("expected empty queue after dequeue")
+	}
+}
+
+func TestQueueEnqueueFromBuildings(t *testing.T) {
+	q := NewQueueManager()
+	f := NewFarmer()
+	b := NewBarracks()
+	f.SetQueue(q)
+	b.SetQueue(q)
+
+	f.interval, f.cooldown = 0.1, 0.1
+	b.interval, b.cooldown = 0.1, 0.1
+
+	f.Update(0.11)
+	b.Update(0.11)
+
+	if q.Len() != 2 {
+		t.Fatalf("expected 2 words in queue got %d", q.Len())
+	}
+}


### PR DESCRIPTION
## Summary
- build QueueManager for global FIFO words
- enqueue Farmer and Barracks words into the queue
- support dequeuing with validation
- test queue behaviour and building integration
- document shared queue in README
- mark P-003 tasks complete in ROADMAP

## Testing
- `go test ./...` *(fails: cannot download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68410d6cab9c8327a2a6bf67c525c942