### PR TITLE
Implement per-building cooldown timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ See the [ROADMAP.md](./ROADMAP.md) for detailed tasks.
 
 - The Farmer building is now implemented as a Gathering structure that generates a word from its letter pool every cooldown cycle (default 3s).
 - Typing the generated word completes the cycle and produces Food resources.
+- Each building's cooldown timer pauses once a word is queued and only resets after that word is typed.
 - The Farmer's cooldown, letter pool, and word length can be configured and extended for progression.
 - See `v1/internal/game/farmer.go` for implementation and `farmer_test.go` for tests.
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -55,6 +55,7 @@ All new features are optional enhancements, preserving the educational and acces
 - **B-GEN-2** Level ups may grant:  
   - Shorter CD, longer word (more output), additional effect (crit, AoE, heal).
 - **B-GEN-3** Buildings can be paused (`p` key) – stops pushing words.
+- **B-GEN-4** Cooldown only resets after the building's pending word is completed.
 - **B-MIL-1** Barracks generates a word every cooldown and spawns a Footman unit when that word is completed.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,9 +29,9 @@
   - [x] Global FIFO queue structure
   - [x] Enqueue from multiple buildings
   - [x] Dequeue and typing validation
-- [ ] **P-004** Per-building cooldown timers
-  - [ ] Timer tick/update logic
-  - [ ] Cooldown reset on word completion
+- [x] **P-004** Per-building cooldown timers
+  - [x] Timer tick/update logic
+  - [x] Cooldown reset on word completion
 - [ ] **P-005** Playtest word density
   - [ ] Simulate 5 min session, measure words/sec
   - [ ] Adjust cooldowns/word lengths for 1–1.5 words/sec target

--- a/v1/internal/game/barracks_test.go
+++ b/v1/internal/game/barracks_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestBarracksCooldownAndWordGeneration(t *testing.T) {
 	b := NewBarracks()
 	b.SetLetterPool([]rune{'f', 'j'})
-	b.interval = 0.1
-	b.cooldown = 0.1
+	b.SetInterval(0.1)
+	b.SetCooldown(0.1)
 	words := make(map[string]struct{})
 	for i := 0; i < 10; i++ {
 		w := b.Update(0.11)
@@ -22,9 +22,27 @@ func TestBarracksCooldownAndWordGeneration(t *testing.T) {
 			}
 		}
 		words[w] = struct{}{}
+		b.OnWordCompleted(w)
 	}
 	if len(words) < 2 {
 		t.Errorf("expected at least 2 unique words, got %d", len(words))
+	}
+}
+
+func TestBarracksWaitsForCompletion(t *testing.T) {
+	b := NewBarracks()
+	b.SetInterval(0.1)
+	b.SetCooldown(0.1)
+	first := b.Update(0.11)
+	if first == "" {
+		t.Fatalf("expected word on cooldown expiry")
+	}
+	if next := b.Update(0.11); next != "" {
+		t.Fatalf("expected no new word until completion")
+	}
+	b.OnWordCompleted(first)
+	if w := b.Update(0.11); w == "" {
+		t.Fatalf("expected new word after completion")
 	}
 }
 

--- a/v1/internal/game/queue_test.go
+++ b/v1/internal/game/queue_test.go
@@ -42,8 +42,10 @@ func TestQueueEnqueueFromBuildings(t *testing.T) {
 	f.SetQueue(q)
 	b.SetQueue(q)
 
-	f.interval, f.cooldown = 0.1, 0.1
-	b.interval, b.cooldown = 0.1, 0.1
+	f.SetInterval(0.1)
+	f.SetCooldown(0.1)
+	b.SetInterval(0.1)
+	b.SetCooldown(0.1)
 
 	f.Update(0.11)
 	b.Update(0.11)

--- a/v1/internal/game/timer.go
+++ b/v1/internal/game/timer.go
@@ -1,0 +1,41 @@
+package game
+
+// CooldownTimer tracks time remaining until an action is ready.
+type CooldownTimer struct {
+	interval  float64
+	remaining float64
+}
+
+// NewCooldownTimer creates a timer with the given interval.
+func NewCooldownTimer(interval float64) CooldownTimer {
+	return CooldownTimer{interval: interval, remaining: interval}
+}
+
+// Tick decreases the timer by dt seconds. It returns true when the timer reaches
+// zero.
+func (t *CooldownTimer) Tick(dt float64) bool {
+	if t.remaining > 0 {
+		t.remaining -= dt
+		if t.remaining < 0 {
+			t.remaining = 0
+		}
+	}
+	return t.remaining <= 0
+}
+
+// Reset sets the timer back to its full interval.
+func (t *CooldownTimer) Reset() { t.remaining = t.interval }
+
+// Ready reports whether the timer has completed.
+func (t *CooldownTimer) Ready() bool { return t.remaining <= 0 }
+
+// SetInterval updates the interval and clamps remaining time if needed.
+func (t *CooldownTimer) SetInterval(interval float64) {
+	t.interval = interval
+	if t.remaining > interval {
+		t.remaining = interval
+	}
+}
+
+// Remaining exposes the time left on the timer.
+func (t *CooldownTimer) Remaining() float64 { return t.remaining }


### PR DESCRIPTION
## Summary
- add reusable `CooldownTimer` struct
- rework Farmer and Barracks to pause cooldowns until words are completed
- update queue tests and building tests for new behaviour
- document cooldown reset behaviour in README and REQUIREMENTS
- mark `P-004` tasks as done in `ROADMAP.md`

## Testing
- `go test ./...` *(fails: downloading toolchain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68410fb9a81c8327a0f8ea13c888da0a