### PR TITLE
Add letter unlock order documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ go test ./...
 - Basic orc grunt waves scale every 45 s.
 - Typing speed/accuracy multiplier working.
 - Vim navigation for pause/menu/shop implemented.
+- Letter unlock order and costs documented (see `docs/LETTER_UNLOCKS.md`).
 
 ---
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -34,7 +34,8 @@ All new features are optional enhancements, preserving the educational and acces
 - **LP-1** Start pool = `f j`.  
 - **LP-2** Letter unlock order is ergonomic (see `docs/LETTER_UNLOCKS.md`).  
 - **LP-3** Each building stores its **own unlock pointer** so two buildings may request different letters at the same tech tier.  
-- **LP-4** Future option: purchase letters directly with Gold (tech-tree node).  
+- **LP-4** Future option: purchase letters directly with Gold (tech-tree node).
+- **LP-5** Unlocking each letter stage costs King's Points and scales per stage (see `docs/LETTER_UNLOCKS.md`).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,10 +35,10 @@
 - [x] **P-005** Playtest word density
   - [x] Simulate 5 min session, measure words/sec
   - [x] Adjust cooldowns/word lengths for 1–1.5 words/sec target
-- [ ] **P-006** Letter unlock order & cost curves
-  - [ ] Draft full unlock order for all buildings
-  - [ ] Define cost progression for each letter unlock
-  - [ ] Document in `docs/LETTER_UNLOCKS.md`
+- [x] **P-006** Letter unlock order & cost curves
+  - [x] Draft full unlock order for all buildings
+  - [x] Define cost progression for each letter unlock
+  - [x] Document in `docs/LETTER_UNLOCKS.md`
 
 ---
 

--- a/docs/LETTER_UNLOCKS.md
+++ b/docs/LETTER_UNLOCKS.md
@@ -1,0 +1,28 @@
+# Letter Unlock Order & Costs
+
+This document defines the planned order in which letters become available to each building family and the King's Point cost to unlock them. Every building tracks its own progress pointer, so you can prioritize certain structures. The sequence is designed to introduce letters from the home row outward for ergonomic learning.
+
+## Global Unlock Sequence
+
+| Stage | Letters Unlocked | Cost (King's Points) |
+|------:|-----------------|---------------------:|
+| 0 | `f`, `j` | 0 |
+| 1 | `d`, `k` | 20 |
+| 2 | `s`, `l` | 40 |
+| 3 | `a` | 60 |
+| 4 | `g`, `h` | 90 |
+| 5 | `q`, `p` | 120 |
+| 6 | `e`, `i` | 150 |
+| 7 | `r`, `u` | 180 |
+| 8 | `t`, `y` | 210 |
+| 9 | `w`, `o` | 240 |
+|10 | `c`, `m` | 270 |
+|11 | `v`, `n` | 310 |
+|12 | `x`, `z` | 350 |
+
+Costs increase roughly every stage to encourage planning and resource management. Later stages may be gated behind additional tech-tree requirements.
+
+## Building Families
+
+All building families (Gathering, Military, Craft & Defense, Economy, Spiritual, Housing) follow this sequence. Because each building stores its own unlock pointer, you might have a Farmer with access up to stage 5 while your Barracks is still at stage 2. Future iterations may diverge per family, but this baseline keeps early progression simple.
+


### PR DESCRIPTION
## Summary
- add documentation for letter unlock order and cost curve
- mark P-006 roadmap tasks as done
- reference letter unlock documentation in README
- note King's Point costs in requirements

## Testing
- `go test ./...` *(fails: toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684111ea8fcc8327ae4903b47a89be72