### PR TITLE
Add family field and color palette

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,8 +18,8 @@
 ## Current Sprint – Queue MVP Hardening
 
 - [ ] **Q-001** Refactor global queue to support color-coding per building
-  - [ ] Add `family` field to `Word` struct
-  - [ ] Palette map + ANSI tests
+  - [x] Add `family` field to `Word` struct
+  - [x] Palette map + ANSI tests
 - [ ] **Q-002** Back-pressure damage when backlog ≥ 5
   - [ ] Unit test: enqueue 6 words, expect base HP −1
 - [ ] **Q-003** Jam state visual

--- a/v1/internal/game/barracks.go
+++ b/v1/internal/game/barracks.go
@@ -37,7 +37,7 @@ func (b *Barracks) Update(dt float64) string {
 		word := b.generateWord()
 		b.pendingWord = word
 		if b.queue != nil {
-			b.queue.Enqueue(Word{Text: word, Source: "Barracks"})
+			b.queue.Enqueue(Word{Text: word, Source: "Barracks", Family: "Military"})
 		}
 		return word
 	}

--- a/v1/internal/game/farmer.go
+++ b/v1/internal/game/farmer.go
@@ -42,7 +42,7 @@ func (f *Farmer) Update(dt float64) string {
 		word := f.generateWord()
 		f.pendingWord = word
 		if f.queue != nil {
-			f.queue.Enqueue(Word{Text: word, Source: "Farmer"})
+			f.queue.Enqueue(Word{Text: word, Source: "Farmer", Family: "Gathering"})
 		}
 		// cooldown resets only after word completion
 		return word

--- a/v1/internal/game/palette.go
+++ b/v1/internal/game/palette.go
@@ -1,0 +1,19 @@
+package game
+
+// ANSI colour codes for building families.
+const (
+	ColorReset = "\033[0m"
+)
+
+var FamilyPalette = map[string]string{
+	"Gathering": "\033[32m", // green
+	"Military":  "\033[31m", // red
+}
+
+// Colorize returns the word text wrapped with the ANSI colour for its family.
+func Colorize(w Word) string {
+	if c, ok := FamilyPalette[w.Family]; ok {
+		return c + w.Text + ColorReset
+	}
+	return w.Text
+}

--- a/v1/internal/game/palette_test.go
+++ b/v1/internal/game/palette_test.go
@@ -1,0 +1,21 @@
+package game
+
+import "testing"
+
+func TestFamilyPaletteValues(t *testing.T) {
+	if FamilyPalette["Gathering"] != "\033[32m" {
+		t.Errorf("Gathering color incorrect: %q", FamilyPalette["Gathering"])
+	}
+	if FamilyPalette["Military"] != "\033[31m" {
+		t.Errorf("Military color incorrect: %q", FamilyPalette["Military"])
+	}
+}
+
+func TestColorize(t *testing.T) {
+	w := Word{Text: "foo", Family: "Gathering"}
+	got := Colorize(w)
+	expected := "\033[32mfoo\033[0m"
+	if got != expected {
+		t.Fatalf("Colorize mismatch: got %q want %q", got, expected)
+	}
+}

--- a/v1/internal/game/queue.go
+++ b/v1/internal/game/queue.go
@@ -4,6 +4,7 @@ package game
 type Word struct {
 	Text   string // text the player must type
 	Source string // name of the building that generated the word
+	Family string // building family for colour coding
 }
 
 // QueueManager maintains a global FIFO queue of words.

--- a/v1/internal/game/queue_test.go
+++ b/v1/internal/game/queue_test.go
@@ -4,21 +4,21 @@ import "testing"
 
 func TestQueueFIFO(t *testing.T) {
 	q := NewQueueManager()
-	q.Enqueue(Word{Text: "one", Source: "farmer"})
-	q.Enqueue(Word{Text: "two", Source: "barracks"})
+	q.Enqueue(Word{Text: "one", Source: "farmer", Family: "Gathering"})
+	q.Enqueue(Word{Text: "two", Source: "barracks", Family: "Military"})
 
 	if q.Len() != 2 {
 		t.Fatalf("expected queue length 2 got %d", q.Len())
 	}
 	w, ok := q.Peek()
-	if !ok || w.Text != "one" || w.Source != "farmer" {
+	if !ok || w.Text != "one" || w.Source != "farmer" || w.Family != "Gathering" {
 		t.Fatalf("unexpected first word: %+v ok=%v", w, ok)
 	}
 }
 
 func TestQueueDequeueValidation(t *testing.T) {
 	q := NewQueueManager()
-	q.Enqueue(Word{Text: "alpha", Source: "farmer"})
+	q.Enqueue(Word{Text: "alpha", Source: "farmer", Family: "Gathering"})
 
 	if _, ok := q.TryDequeue("beta"); ok {
 		t.Fatalf("dequeue should fail for wrong input")
@@ -27,7 +27,7 @@ func TestQueueDequeueValidation(t *testing.T) {
 		t.Fatalf("queue length changed on failed dequeue")
 	}
 	w, ok := q.TryDequeue("alpha")
-	if !ok || w.Text != "alpha" {
+	if !ok || w.Text != "alpha" || w.Family != "Gathering" {
 		t.Fatalf("dequeue failed for correct input")
 	}
 	if q.Len() != 0 {


### PR DESCRIPTION
## Summary
- extend `Word` struct with a `Family` field
- enqueue farmer/barracks words with new family field
- create palette map and colorization utility
- test queue with family field
- add palette tests
- mark roadmap subtasks complete

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841142cf7b88327bdc846fcdf12721e