### PR TITLE
Implement backlog damage

### DIFF
--- a/v1/internal/game/queue_test.go
+++ b/v1/internal/game/queue_test.go
@@ -54,3 +54,16 @@ func TestQueueEnqueueFromBuildings(t *testing.T) {
 		t.Fatalf("expected 2 words in queue got %d", q.Len())
 	}
 }
+
+func TestQueueBackPressureDamage(t *testing.T) {
+	q := NewQueueManager()
+	base := NewBase(0, 0, 5)
+	q.SetBase(base)
+	for i := 0; i < 6; i++ {
+		q.Enqueue(Word{Text: "w"})
+	}
+	q.Update(1.0)
+	if base.Health() != 4 {
+		t.Fatalf("expected base health 4 got %d", base.Health())
+	}
+}


### PR DESCRIPTION
## Summary
- introduce `QueueManager.Update` to apply back-pressure
- track base pointer and timer inside `QueueManager`
- add unit test for back-pressure damage when backlog ≥5

## Testing
- `go test ./...` *(fails: forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_684115420b708327a4e66b411012c0b3