### PR TITLE
Implement letter unlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ go test ./...
 - Typing speed/accuracy multiplier working.
 - Vim navigation for pause/menu/shop implemented.
 - Letter unlock order and costs documented (see `docs/LETTER_UNLOCKS.md`).
+- Letters can now be unlocked in-game using King's Points, expanding each building's word pool.
 
 ---
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -92,6 +92,7 @@ All new features are optional enhancements, preserving the educational and acces
 
 - **ECO-1** The game maintains a `ResourcePool` struct aggregating Gold, Food, Wood, Stone and Iron.
 - **ECO-2** Buildings like the Farmer deposit resources into this pool when their words are completed.
+- **ECO-3** King's Points are tracked in the `ResourcePool` and spent on letter unlocks.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,10 +36,10 @@
 - [ ] **INT-006** Integrate Jam State Visuals and Audio
   - [ ] Implement red flash on mistype.
   - [ ] Implement "clank" SFX placeholder on mistype.
-- [ ] **INT-007** Implement Letter Unlock System
-  - [ ] Create UI for viewing and purchasing letter unlocks as per `docs/LETTER_UNLOCKS.md`.
-  - [ ] Connect letter unlocks to word generation logic for buildings.
-  - [ ] Ensure resource costs for unlocks are deducted correctly.
+- [x] **INT-007** Implement Letter Unlock System
+  - [x] Create UI for viewing and purchasing letter unlocks as per `docs/LETTER_UNLOCKS.md`.
+  - [x] Connect letter unlocks to word generation logic for buildings.
+  - [x] Ensure resource costs for unlocks are deducted correctly.
 - [ ] **TEST-CORELOOP** End-to-end playtest of the core loop
   - [ ] Verify resource gathering from Farmer.
   - [ ] Verify letter unlocking and its effect on word generation.

--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -421,7 +421,7 @@ func (g *Game) Update() error {
 			upgradeFireRateCost  = 5
 			upgradeAmmoCost      = 10
 			upgradeForesightCost = 5
-			optionsCount         = 6
+			optionsCount         = 8
 		)
 
 		if g.input.Down() {
@@ -464,6 +464,14 @@ func (g *Game) Update() error {
 						tower.UpgradeForesight(2)
 						return true
 					}
+				case 5:
+					if g.farmer != nil {
+						return g.farmer.UnlockNext(&g.resources)
+					}
+				case 6:
+					if g.barracks != nil {
+						return g.barracks.UnlockNext(&g.resources)
+					}
 				}
 				return false
 			}
@@ -484,9 +492,15 @@ func (g *Game) Update() error {
 			if inpututil.IsKeyJustPressed(ebiten.Key5) {
 				purchase(4)
 			}
+			if inpututil.IsKeyJustPressed(ebiten.Key6) {
+				purchase(5)
+			}
+			if inpututil.IsKeyJustPressed(ebiten.Key7) {
+				purchase(6)
+			}
 
 			if g.input.Enter() {
-				if g.shopCursor < 5 {
+				if g.shopCursor < 7 {
 					purchase(g.shopCursor)
 				} else {
 					g.shopOpen = false

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -84,6 +84,7 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 		lines = append(lines, "-- SHOP --")
 		lines = append(lines, fmt.Sprintf("Gold: %d", gold))
 		lines = append(lines, fmt.Sprintf("Food: %d", h.game.resources.FoodAmount()))
+		lines = append(lines, fmt.Sprintf("KP: %d", h.game.resources.KingsAmount()))
 
 		var foresight int
 		if len(h.game.towers) > 0 {
@@ -96,6 +97,8 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 			"[3] Upgrade Fire Rate (faster): 5 gold",
 			"[4] Upgrade Ammo Capacity (+2): 10 gold",
 			fmt.Sprintf("[5] Foresight (+2 letters) [%d]", foresight),
+			fmt.Sprintf("[6] Unlock Farmer Letters (%d KP)", h.game.farmer.NextUnlockCost()),
+			fmt.Sprintf("[7] Unlock Barracks Letters (%d KP)", h.game.barracks.NextUnlockCost()),
 			"Start Next Wave",
 		}
 
@@ -181,7 +184,7 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 		if h.game.base != nil {
 			lines = append(lines, fmt.Sprintf("Base HP: %d", h.game.base.Health()))
 		}
-		lines = append(lines, fmt.Sprintf("Wave %d | Gold %d | Food %d | Score %d | Mobs %d", h.game.currentWave, h.game.Gold(), h.game.resources.FoodAmount(), h.game.score, len(h.game.mobs)))
+		lines = append(lines, fmt.Sprintf("Wave %d | Gold %d | Food %d | KP %d | Score %d | Mobs %d", h.game.currentWave, h.game.Gold(), h.game.resources.FoodAmount(), h.game.resources.KingsAmount(), h.game.score, len(h.game.mobs)))
 		acc := h.game.typing.Accuracy() * 100
 		wpm := h.game.typing.WPM()
 		lines = append(lines, fmt.Sprintf("Accuracy: %.0f%% | WPM: %.1f", acc, wpm))

--- a/v1/internal/game/letter_unlock_test.go
+++ b/v1/internal/game/letter_unlock_test.go
@@ -1,0 +1,19 @@
+package game
+
+import "testing"
+
+func TestLetterUnlockDeductsPoints(t *testing.T) {
+	f := NewFarmer()
+	pool := &ResourcePool{}
+	pool.AddKingsPoints(100)
+	cost := f.NextUnlockCost()
+	if !f.UnlockNext(pool) {
+		t.Fatalf("unlock should succeed")
+	}
+	if pool.KingsAmount() != 100-cost {
+		t.Fatalf("expected %d KP remaining got %d", 100-cost, pool.KingsAmount())
+	}
+	if len(f.letterPool) <= 2 {
+		t.Fatalf("letters not added")
+	}
+}

--- a/v1/internal/game/letter_unlocks.go
+++ b/v1/internal/game/letter_unlocks.go
@@ -1,0 +1,40 @@
+package game
+
+// LetterStage defines letters unlocked at each stage and their King's Point cost.
+type LetterStage struct {
+	Letters []rune
+	Cost    int
+}
+
+// LetterUnlockStages is the ordered progression for unlocking letters.
+var LetterUnlockStages = []LetterStage{
+	{Letters: []rune{'f', 'j'}, Cost: 0},
+	{Letters: []rune{'d', 'k'}, Cost: 20},
+	{Letters: []rune{'s', 'l'}, Cost: 40},
+	{Letters: []rune{'a'}, Cost: 60},
+	{Letters: []rune{'g', 'h'}, Cost: 90},
+	{Letters: []rune{'q', 'p'}, Cost: 120},
+	{Letters: []rune{'e', 'i'}, Cost: 150},
+	{Letters: []rune{'r', 'u'}, Cost: 180},
+	{Letters: []rune{'t', 'y'}, Cost: 210},
+	{Letters: []rune{'w', 'o'}, Cost: 240},
+	{Letters: []rune{'c', 'm'}, Cost: 270},
+	{Letters: []rune{'v', 'n'}, Cost: 310},
+	{Letters: []rune{'x', 'z'}, Cost: 350},
+}
+
+// LetterStageLetters returns the letters unlocked at the given stage.
+func LetterStageLetters(stage int) []rune {
+	if stage < 0 || stage >= len(LetterUnlockStages) {
+		return nil
+	}
+	return LetterUnlockStages[stage].Letters
+}
+
+// LetterStageCost returns the King's Point cost for the given stage.
+func LetterStageCost(stage int) int {
+	if stage < 0 || stage >= len(LetterUnlockStages) {
+		return -1
+	}
+	return LetterUnlockStages[stage].Cost
+}

--- a/v1/internal/game/resource.go
+++ b/v1/internal/game/resource.go
@@ -115,6 +115,29 @@ func (f *Food) Amount() int { return f.amount }
 // Set sets the food amount directly.
 func (f *Food) Set(n int) { f.amount = n }
 
+// KingsPoints tracks special currency used for letter unlocks.
+type KingsPoints struct {
+	amount int
+}
+
+// Add increases the points amount.
+func (k *KingsPoints) Add(n int) { k.amount += n }
+
+// Spend subtracts the given amount if available and returns true.
+func (k *KingsPoints) Spend(n int) bool {
+	if k.amount < n {
+		return false
+	}
+	k.amount -= n
+	return true
+}
+
+// Amount returns the current points total.
+func (k *KingsPoints) Amount() int { return k.amount }
+
+// Set sets the points amount directly.
+func (k *KingsPoints) Set(n int) { k.amount = n }
+
 // ResourcePool aggregates all resource types for the player.
 type ResourcePool struct {
 	Gold  Gold
@@ -122,6 +145,7 @@ type ResourcePool struct {
 	Wood  Wood
 	Stone Stone
 	Iron  Iron
+	Kings KingsPoints
 }
 
 // AddGold adds the specified amount of gold.
@@ -135,3 +159,12 @@ func (r *ResourcePool) GoldAmount() int { return r.Gold.Amount() }
 
 // FoodAmount returns the current food total.
 func (r *ResourcePool) FoodAmount() int { return r.Food.Amount() }
+
+// AddKingsPoints adds the specified amount of King's Points.
+func (r *ResourcePool) AddKingsPoints(n int) { r.Kings.Add(n) }
+
+// SpendKingsPoints attempts to spend the given amount and returns true on success.
+func (r *ResourcePool) SpendKingsPoints(n int) bool { return r.Kings.Spend(n) }
+
+// KingsAmount returns the current King's Points total.
+func (r *ResourcePool) KingsAmount() int { return r.Kings.Amount() }

--- a/v1/internal/game/resource_test.go
+++ b/v1/internal/game/resource_test.go
@@ -60,3 +60,17 @@ func TestIron(t *testing.T) {
 		t.Fatalf("spend should fail when empty")
 	}
 }
+
+func TestKingsPoints(t *testing.T) {
+	var k KingsPoints
+	k.Add(50)
+	if k.Amount() != 50 {
+		t.Fatalf("expected 50 got %d", k.Amount())
+	}
+	if !k.Spend(20) || k.Amount() != 30 {
+		t.Fatalf("unexpected spend result %d", k.Amount())
+	}
+	if k.Spend(40) {
+		t.Fatalf("spend should fail when insufficient")
+	}
+}


### PR DESCRIPTION
## Summary
- add King's Points resource and tracking
- implement letter unlock stages and per-building unlocking
- extend shop UI to purchase unlocks
- track new resource in HUD and scoreboard
- test letter unlock purchases
- mark INT-007 as complete

## Testing
- `go test ./...` *(fails: Forbidden downloading toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68411fbd7c7c8327891e7417f642349a