### PR TITLE
Implement resource buildings

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ See the [ROADMAP.md](./ROADMAP.md) for detailed tasks.
 - The Farmer's cooldown, letter pool, and word length can be configured and extended for progression.
 - See `v1/internal/game/farmer.go` for implementation and `farmer_test.go` for tests.
 
+## Lumberjack (Gathering Building)
+
+- The Lumberjack produces Wood and Gold when its queued word is typed.
+- Shares similar mechanics to the Farmer with a 1.5s base cooldown.
+- Implementation lives in `v1/internal/game/lumberjack.go`.
+
+## Miner (Gathering Building)
+
+- The Miner yields Stone and Iron plus a bit of Gold on completion.
+- Follows the same word-based workflow and cooldown system.
+- See `v1/internal/game/miner.go` for code and tests.
+
 -## Barracks (Military Building)
 
 - The Barracks building generates a word from its letter pool every 2 seconds.

--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -99,10 +99,12 @@ type Game struct {
 	flashTimer float64
 
 	// Building integration
-	queue    *QueueManager
-	farmer   *Farmer
-	barracks *Barracks
-	military *Military
+	queue      *QueueManager
+	farmer     *Farmer
+	lumberjack *Lumberjack
+	miner      *Miner
+	barracks   *Barracks
+	military   *Military
 
 	// Typing state for the queue
 	queueIndex int
@@ -171,6 +173,8 @@ func NewGameWithHistory(cfg Config, hist *PerformanceHistory) *Game {
 		flashTimer:      0,
 		queue:           NewQueueManager(),
 		farmer:          NewFarmer(),
+		lumberjack:      NewLumberjack(),
+		miner:           NewMiner(),
 		barracks:        NewBarracks(),
 		military:        NewMilitary(),
 	}
@@ -191,6 +195,8 @@ func NewGameWithHistory(cfg Config, hist *PerformanceHistory) *Game {
 	// Wire up shared systems
 	g.queue.SetBase(g.base)
 	g.farmer.SetQueue(g.queue)
+	g.lumberjack.SetQueue(g.queue)
+	g.miner.SetQueue(g.queue)
 	g.barracks.SetQueue(g.queue)
 	g.barracks.SetMilitary(g.military)
 
@@ -531,6 +537,16 @@ func (g *Game) Update() error {
 	if g.farmer != nil {
 		if w := g.farmer.Update(dt); w != "" {
 			g.farmer.OnWordCompleted(w, &g.resources)
+		}
+	}
+	if g.lumberjack != nil {
+		if w := g.lumberjack.Update(dt); w != "" {
+			g.lumberjack.OnWordCompleted(w, &g.resources)
+		}
+	}
+	if g.miner != nil {
+		if w := g.miner.Update(dt); w != "" {
+			g.miner.OnWordCompleted(w, &g.resources)
 		}
 	}
 	if g.barracks != nil {

--- a/v1/internal/game/game_step_test.go
+++ b/v1/internal/game/game_step_test.go
@@ -52,6 +52,12 @@ func (g *Game) Step(dt float64) error {
 	if g.farmer != nil {
 		g.farmer.Update(dt)
 	}
+	if g.lumberjack != nil {
+		g.lumberjack.Update(dt)
+	}
+	if g.miner != nil {
+		g.miner.Update(dt)
+	}
 	if g.barracks != nil {
 		g.barracks.Update(dt)
 	}

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -35,6 +35,20 @@ func NewHUD(g *Game) *HUD {
 	return &HUD{game: g}
 }
 
+// drawResources renders a simple resource bar at the top left.
+func (h *HUD) drawResources(screen *ebiten.Image) {
+	gold := h.game.resources.GoldAmount()
+	wood := h.game.resources.WoodAmount()
+	stone := h.game.resources.StoneAmount()
+	iron := h.game.resources.IronAmount()
+	mana := 0
+	textStr := fmt.Sprintf("G:%d W:%d S:%d I:%d M:%d", gold, wood, stone, iron, mana)
+	opts := &text.DrawOptions{}
+	opts.GeoM.Translate(10, 10)
+	opts.ColorScale.ScaleWithColor(color.White)
+	text.Draw(screen, textStr, BoldFont, opts)
+}
+
 // drawQueue renders the global typing queue at the top center of the screen.
 func (h *HUD) drawQueue(screen *ebiten.Image) {
 	if h.game.queue == nil {
@@ -72,6 +86,7 @@ func (h *HUD) drawQueue(screen *ebiten.Image) {
 
 // Draw renders ammo count, tower stats, reload prompts, and shop interface.
 func (h *HUD) Draw(screen *ebiten.Image) {
+	h.drawResources(screen)
 	h.drawQueue(screen)
 	var lines []string
 	textX := 10

--- a/v1/internal/game/lumberjack.go
+++ b/v1/internal/game/lumberjack.go
@@ -1,0 +1,101 @@
+package game
+
+import "math/rand"
+
+// Lumberjack represents a Gathering building that produces Wood on cooldown.
+type Lumberjack struct {
+	timer       CooldownTimer
+	letterPool  []rune
+	unlockStage int
+	wordLenMin  int
+	wordLenMax  int
+	lastWord    string
+	pendingWord string
+	resourceOut int
+	active      bool
+	queue       *QueueManager
+}
+
+// NewLumberjack creates a new Lumberjack with default settings.
+func NewLumberjack() *Lumberjack {
+	return &Lumberjack{
+		timer:       NewCooldownTimer(1.5),
+		letterPool:  []rune{'f', 'j'},
+		unlockStage: 0,
+		wordLenMin:  2,
+		wordLenMax:  4,
+		resourceOut: 1,
+		active:      true,
+	}
+}
+
+// Update ticks the Lumberjack cooldown and pushes a word if ready.
+func (l *Lumberjack) Update(dt float64) string {
+	if !l.active || l.pendingWord != "" {
+		return ""
+	}
+	if l.timer.Tick(dt) {
+		word := l.generateWord()
+		l.pendingWord = word
+		if l.queue != nil {
+			l.queue.Enqueue(Word{Text: word, Source: "Lumberjack", Family: "Gathering"})
+		}
+		return word
+	}
+	return ""
+}
+
+func (l *Lumberjack) generateWord() string {
+	length := l.wordLenMin
+	if l.wordLenMax > l.wordLenMin {
+		length += rand.Intn(l.wordLenMax - l.wordLenMin + 1)
+	}
+	word := make([]rune, length)
+	for i := 0; i < length; i++ {
+		word[i] = l.letterPool[rand.Intn(len(l.letterPool))]
+	}
+	l.lastWord = string(word)
+	return l.lastWord
+}
+
+// OnWordCompleted should be called when the word is typed. Returns wood gained.
+func (l *Lumberjack) OnWordCompleted(word string, pool *ResourcePool) int {
+	if word == l.pendingWord {
+		l.pendingWord = ""
+		l.timer.Reset()
+		if pool != nil {
+			pool.AddGold(l.resourceOut)
+			pool.AddWood(l.resourceOut)
+		}
+		return l.resourceOut
+	}
+	return 0
+}
+
+func (l *Lumberjack) SetLetterPool(p []rune)     { l.letterPool = p }
+func (l *Lumberjack) SetActive(a bool)           { l.active = a }
+func (l *Lumberjack) SetInterval(d float64)      { l.timer.SetInterval(d) }
+func (l *Lumberjack) SetCooldown(c float64)      { l.timer.remaining = c }
+func (l *Lumberjack) SetQueue(q *QueueManager)   { l.queue = q }
+func (l *Lumberjack) CooldownProgress() float64  { return l.timer.Progress() }
+func (l *Lumberjack) CooldownRemaining() float64 { return l.timer.Remaining() }
+
+func (l *Lumberjack) NextUnlockCost() int {
+	stage := l.unlockStage + 1
+	return LetterStageCost(stage)
+}
+
+func (l *Lumberjack) UnlockNext(pool *ResourcePool) bool {
+	stage := l.unlockStage + 1
+	letters := LetterStageLetters(stage)
+	cost := LetterStageCost(stage)
+	if letters == nil || cost < 0 {
+		return false
+	}
+	if pool != nil && pool.SpendKingsPoints(cost) {
+		l.unlockStage = stage
+		l.letterPool = append(l.letterPool, letters...)
+		return true
+	}
+	return false
+}

--- a/v1/internal/game/lumberjack_test.go
+++ b/v1/internal/game/lumberjack_test.go
@@ -1,0 +1,39 @@
+package game
+
+import "testing"
+
+func TestLumberjackCooldownAndWordGeneration(t *testing.T) {
+	l := NewLumberjack()
+	l.SetLetterPool([]rune{'f', 'j'})
+	l.SetInterval(0.1)
+	l.SetCooldown(0.1)
+	words := make(map[string]struct{})
+	for i := 0; i < 10; i++ {
+		w := l.Update(0.11)
+		if w == "" {
+			t.Fatalf("expected word on cooldown expiry")
+		}
+		if len(w) < l.wordLenMin || len(w) > l.wordLenMax {
+			t.Errorf("word length out of bounds: %s", w)
+		}
+		words[w] = struct{}{}
+		l.OnWordCompleted(w, nil)
+	}
+	if len(words) < 2 {
+		t.Errorf("expected multiple unique words")
+	}
+}
+
+func TestLumberjackResourceOutput(t *testing.T) {
+	l := NewLumberjack()
+	word := l.generateWord()
+	l.pendingWord = word
+	pool := &ResourcePool{}
+	wood := l.OnWordCompleted(word, pool)
+	if wood != l.resourceOut {
+		t.Fatalf("expected %d wood got %d", l.resourceOut, wood)
+	}
+	if pool.WoodAmount() != l.resourceOut || pool.GoldAmount() != l.resourceOut {
+		t.Fatalf("resources not added")
+	}
+}

--- a/v1/internal/game/miner.go
+++ b/v1/internal/game/miner.go
@@ -1,0 +1,104 @@
+package game
+
+import "math/rand"
+
+// Miner represents a Gathering building that produces Stone and Iron on cooldown.
+type Miner struct {
+	timer       CooldownTimer
+	letterPool  []rune
+	unlockStage int
+	wordLenMin  int
+	wordLenMax  int
+	lastWord    string
+	pendingWord string
+	stoneOut    int
+	ironOut     int
+	active      bool
+	queue       *QueueManager
+}
+
+// NewMiner creates a new Miner with default settings.
+func NewMiner() *Miner {
+	return &Miner{
+		timer:       NewCooldownTimer(1.5),
+		letterPool:  []rune{'f', 'j'},
+		unlockStage: 0,
+		wordLenMin:  2,
+		wordLenMax:  4,
+		stoneOut:    1,
+		ironOut:     1,
+		active:      true,
+	}
+}
+
+// Update ticks the Miner cooldown and pushes a word if ready.
+func (m *Miner) Update(dt float64) string {
+	if !m.active || m.pendingWord != "" {
+		return ""
+	}
+	if m.timer.Tick(dt) {
+		word := m.generateWord()
+		m.pendingWord = word
+		if m.queue != nil {
+			m.queue.Enqueue(Word{Text: word, Source: "Miner", Family: "Gathering"})
+		}
+		return word
+	}
+	return ""
+}
+
+func (m *Miner) generateWord() string {
+	length := m.wordLenMin
+	if m.wordLenMax > m.wordLenMin {
+		length += rand.Intn(m.wordLenMax - m.wordLenMin + 1)
+	}
+	word := make([]rune, length)
+	for i := 0; i < length; i++ {
+		word[i] = m.letterPool[rand.Intn(len(m.letterPool))]
+	}
+	m.lastWord = string(word)
+	return m.lastWord
+}
+
+// OnWordCompleted should be called when the word is typed. Returns stone gained.
+func (m *Miner) OnWordCompleted(word string, pool *ResourcePool) (int, int) {
+	if word == m.pendingWord {
+		m.pendingWord = ""
+		m.timer.Reset()
+		if pool != nil {
+			pool.AddGold(m.stoneOut)
+			pool.AddStone(m.stoneOut)
+			pool.AddIron(m.ironOut)
+		}
+		return m.stoneOut, m.ironOut
+	}
+	return 0, 0
+}
+
+func (m *Miner) SetLetterPool(p []rune)     { m.letterPool = p }
+func (m *Miner) SetActive(a bool)           { m.active = a }
+func (m *Miner) SetInterval(d float64)      { m.timer.SetInterval(d) }
+func (m *Miner) SetCooldown(c float64)      { m.timer.remaining = c }
+func (m *Miner) SetQueue(q *QueueManager)   { m.queue = q }
+func (m *Miner) CooldownProgress() float64  { return m.timer.Progress() }
+func (m *Miner) CooldownRemaining() float64 { return m.timer.Remaining() }
+
+func (m *Miner) NextUnlockCost() int {
+	stage := m.unlockStage + 1
+	return LetterStageCost(stage)
+}
+
+func (m *Miner) UnlockNext(pool *ResourcePool) bool {
+	stage := m.unlockStage + 1
+	letters := LetterStageLetters(stage)
+	cost := LetterStageCost(stage)
+	if letters == nil || cost < 0 {
+		return false
+	}
+	if pool != nil && pool.SpendKingsPoints(cost) {
+		m.unlockStage = stage
+		m.letterPool = append(m.letterPool, letters...)
+		return true
+	}
+	return false
+}

--- a/v1/internal/game/miner_test.go
+++ b/v1/internal/game/miner_test.go
@@ -1,0 +1,39 @@
+package game
+
+import "testing"
+
+func TestMinerCooldownAndWordGeneration(t *testing.T) {
+	m := NewMiner()
+	m.SetLetterPool([]rune{'f', 'j'})
+	m.SetInterval(0.1)
+	m.SetCooldown(0.1)
+	words := make(map[string]struct{})
+	for i := 0; i < 10; i++ {
+		w := m.Update(0.11)
+		if w == "" {
+			t.Fatalf("expected word on cooldown expiry")
+		}
+		if len(w) < m.wordLenMin || len(w) > m.wordLenMax {
+			t.Errorf("word length out of bounds: %s", w)
+		}
+		words[w] = struct{}{}
+		m.OnWordCompleted(w, nil)
+	}
+	if len(words) < 2 {
+		t.Errorf("expected multiple unique words")
+	}
+}
+
+func TestMinerResourceOutput(t *testing.T) {
+	m := NewMiner()
+	word := m.generateWord()
+	m.pendingWord = word
+	pool := &ResourcePool{}
+	stone, iron := m.OnWordCompleted(word, pool)
+	if stone != m.stoneOut || iron != m.ironOut {
+		t.Fatalf("unexpected resource amounts")
+	}
+	if pool.StoneAmount() != stone || pool.IronAmount() != iron {
+		t.Fatalf("resources not added")
+	}
+}

--- a/v1/internal/game/resource.go
+++ b/v1/internal/game/resource.go
@@ -154,11 +154,29 @@ func (r *ResourcePool) AddGold(n int) { r.Gold.Add(n) }
 // AddFood adds the specified amount of food.
 func (r *ResourcePool) AddFood(n int) { r.Food.Add(n) }
 
+// AddWood adds the specified amount of wood.
+func (r *ResourcePool) AddWood(n int) { r.Wood.Add(n) }
+
+// AddStone adds the specified amount of stone.
+func (r *ResourcePool) AddStone(n int) { r.Stone.Add(n) }
+
+// AddIron adds the specified amount of iron.
+func (r *ResourcePool) AddIron(n int) { r.Iron.Add(n) }
+
 // GoldAmount returns the current gold total.
 func (r *ResourcePool) GoldAmount() int { return r.Gold.Amount() }
 
 // FoodAmount returns the current food total.
 func (r *ResourcePool) FoodAmount() int { return r.Food.Amount() }
+
+// WoodAmount returns the current wood total.
+func (r *ResourcePool) WoodAmount() int { return r.Wood.Amount() }
+
+// StoneAmount returns the current stone total.
+func (r *ResourcePool) StoneAmount() int { return r.Stone.Amount() }
+
+// IronAmount returns the current iron total.
+func (r *ResourcePool) IronAmount() int { return r.Iron.Amount() }
 
 // AddKingsPoints adds the specified amount of King's Points.
 func (r *ResourcePool) AddKingsPoints(n int) { r.Kings.Add(n) }

--- a/v1/internal/game/resources_integration_test.go
+++ b/v1/internal/game/resources_integration_test.go
@@ -1,0 +1,27 @@
+//go:build test
+
+package game
+
+import "testing"
+
+// TestResourcesAccumulation simulates several minutes to ensure resources grow.
+func TestResourcesAccumulation(t *testing.T) {
+	g := NewGame()
+	inp := &stubInput{}
+	g.input = inp
+
+	steps := 1800 // 180 seconds at 0.1 dt
+	dt := 0.1
+	for i := 0; i < steps; i++ {
+		if w, ok := g.Queue().Peek(); ok {
+			inp.typed = []rune(w.Text)
+		}
+		if err := g.Step(dt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if g.resources.GoldAmount() == 0 || g.resources.WoodAmount() == 0 || g.resources.StoneAmount() == 0 || g.resources.IronAmount() == 0 {
+		t.Fatalf("expected resources to accumulate")
+	}
+}


### PR DESCRIPTION
## Summary
- add lumberjack and miner building types
- extend resource pool with wood, stone, and iron helpers
- show resource totals on the HUD
- document new buildings in README
- integration tests for resource generation

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841250a5bd483279fe7fe4ec2238acb