### PR TITLE
Fix queue backpressure damage

### DIFF
--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -251,9 +251,6 @@ func (g *Game) Update() error {
 		}
 		g.conveyorOffset -= shift
 	}
-	if g.queue != nil {
-		g.queue.Update(dt)
-	}
 
 	if g.flashTimer > 0 {
 		g.flashTimer -= dt


### PR DESCRIPTION
## Summary
- avoid calling Queue.Update twice per frame

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: forbidden to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684194609cd8832782984ac9a437cabe