### PR TITLE
Implement title screen main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ go test -tags test ./...
  - Back-pressure damage: if the queue grows past 20 letters, the base loses 1 HP each second.
 - Typing speed/accuracy multiplier working.
 - Vim navigation for pause/menu/shop implemented.
+- Title screen with animated background and keyboard-only menu.
 - Letter unlock order and costs documented (see `docs/LETTER_UNLOCKS.md`).
 - Letters can now be unlocked in-game using King's Points, expanding each building's word pool.
 - Tech trees are defined in YAML under `data/trees/` (see `letters_basic.yaml`).

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -118,6 +118,8 @@ All new features are optional enhancements, preserving the educational and acces
 | **UI-NAV-4** | Hot-reload config `F5`. |
 | **UI-NAV-5** | Key-rebinder supports QWERTY, Colemak, Dvorak. |
 | **UI-BUILD-1** | HUD displays cooldown progress for Farmer and Barracks. |
+| **UI-TITLE-1** | Game starts at a title screen with Start, Settings and Quit options. |
+| **UI-TITLE-2** | Title screen has a simple animated background and is keyboard navigable. |
 
 *Planned: Typed commands for minion management, skill tree navigation, and minigames. All new features remain keyboard-only.*
 
@@ -128,6 +130,7 @@ All new features are optional enhancements, preserving the educational and acces
 - **SND-1** 8-bit SFX for key hits, crits, jams.
 - **FX-1** Mistyped letters briefly flash the screen red and play a "clank" sound.
 - **SND-2** Optional voice-over reads next word for early readers (accessibility toggle).
+- **SND-3** Background music loops on the title screen.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,8 +27,8 @@
   - [ ] `/` to enter tower selection mode, letter labels, upgrade menu
 - [ ] **CMD-001** Command mode for power users
   - [ ] `:` to enter command mode, basic and advanced commands
-- [ ] **TITLE-001** Title screen and main menu
-  - [ ] MainMenuState, logo, background music, animated background, settings
+- [x] **TITLE-001** Title screen and main menu
+  - [x] MainMenuState, logo, background music, animated background, settings
 - [ ] **PREGAME-001** Pre-game setup and tutorial
   - [ ] Character/difficulty selection, tutorial, typing test, mode selection
 

--- a/v1/internal/game/mainmenu.go
+++ b/v1/internal/game/mainmenu.go
@@ -1,0 +1,125 @@
+package game
+
+import (
+	"image/color"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+// MainMenu handles the title screen UI and behavior.
+type MainMenu struct {
+	options        []string
+	cursor         int
+	animOffset     float64
+	inSettings     bool
+	settingsCursor int
+}
+
+// NewMainMenu creates a default MainMenu instance.
+func NewMainMenu() *MainMenu {
+	return &MainMenu{options: []string{"Start Game", "Settings", "Quit"}}
+}
+
+// Update processes input for the main menu. Returns ebiten.Termination when
+// the user chooses to quit.
+func (m *MainMenu) Update(g *Game, dt float64) error {
+	m.animOffset += dt * 30
+	if m.inSettings {
+		if g.input.Down() {
+			m.settingsCursor = (m.settingsCursor + 1) % 2
+		}
+		if g.input.Up() {
+			m.settingsCursor = (m.settingsCursor - 1 + 2) % 2
+		}
+		if g.input.Enter() {
+			switch m.settingsCursor {
+			case 0:
+				g.settings.Mute = !g.settings.Mute
+				if g.sound != nil {
+					g.sound.ToggleMute()
+				}
+			case 1:
+				m.inSettings = false
+			}
+		}
+		return nil
+	}
+	if g.input.Down() {
+		m.cursor = (m.cursor + 1) % len(m.options)
+	}
+	if g.input.Up() {
+		m.cursor = (m.cursor - 1 + len(m.options)) % len(m.options)
+	}
+	if g.input.Enter() {
+		switch m.cursor {
+		case 0:
+			g.phase = PhasePlaying
+			g.startWave()
+			if g.sound != nil {
+				g.sound.StopMusic()
+				g.sound.PlayBeep()
+			}
+		case 1:
+			m.inSettings = true
+			m.settingsCursor = 0
+		case 2:
+			if g.sound != nil {
+				g.sound.StopMusic()
+			}
+			return ebiten.Termination
+		}
+	}
+	return nil
+}
+
+// Draw renders the menu to the given screen.
+func (m *MainMenu) Draw(g *Game, screen *ebiten.Image) {
+	screen.Clear()
+	drawScrollingBackground(screen, m.animOffset)
+	titleOpts := &text.DrawOptions{}
+	titleOpts.GeoM.Translate(760, 200)
+	titleOpts.ColorScale.ScaleWithColor(color.White)
+	text.Draw(screen, "TypingTowers", BoldFont, titleOpts)
+
+	var lines []string
+	if m.inSettings {
+		mute := "Off"
+		if g.settings.Mute {
+			mute = "On"
+		}
+		opts := []string{"Toggle Mute: " + mute, "Back"}
+		for i, opt := range opts {
+			prefix := "  "
+			if i == m.settingsCursor {
+				prefix = "> "
+			}
+			lines = append(lines, prefix+opt)
+		}
+		drawMenu(screen, append([]string{"-- SETTINGS --"}, lines...), 860, 480)
+		return
+	}
+	for i, opt := range m.options {
+		prefix := "  "
+		if i == m.cursor {
+			prefix = "> "
+		}
+		lines = append(lines, prefix+opt)
+	}
+	drawMenu(screen, append([]string{"-- MAIN MENU --"}, lines...), 860, 480)
+}
+
+// drawScrollingBackground renders a vertically scrolling background.
+func drawScrollingBackground(screen *ebiten.Image, offset float64) {
+	if ImgBackgroundBasicTiles == nil {
+		return
+	}
+	h := ImgBackgroundBasicTiles.Bounds().Dy()
+	oy := int(offset) % h
+	op := &ebiten.DrawImageOptions{}
+	op.GeoM.Translate(0, float64(oy))
+	screen.DrawImage(ImgBackgroundBasicTiles, op)
+	op2 := &ebiten.DrawImageOptions{}
+	op2.GeoM.Translate(0, float64(oy-h))
+	screen.DrawImage(ImgBackgroundBasicTiles, op2)
+}

--- a/v1/internal/game/mainmenu_test.go
+++ b/v1/internal/game/mainmenu_test.go
@@ -1,0 +1,83 @@
+//go:build test
+
+package game
+
+import (
+	"testing"
+	"time"
+)
+
+// menuInput implements InputHandler for menu navigation tests.
+type menuInput struct {
+	up, down, enter bool
+}
+
+func (m *menuInput) TypedChars() []rune { return nil }
+func (m *menuInput) Update()            {}
+func (m *menuInput) Reset()             { m.up, m.down, m.enter = false, false, false }
+func (m *menuInput) Backspace() bool    { return false }
+func (m *menuInput) Space() bool        { return false }
+func (m *menuInput) Quit() bool         { return false }
+func (m *menuInput) Reload() bool       { return false }
+func (m *menuInput) Enter() bool        { return m.enter }
+func (m *menuInput) Left() bool         { return false }
+func (m *menuInput) Right() bool        { return false }
+func (m *menuInput) Up() bool           { return m.up }
+func (m *menuInput) Down() bool         { return m.down }
+func (m *menuInput) Build() bool        { return false }
+func (m *menuInput) Save() bool         { return false }
+func (m *menuInput) Load() bool         { return false }
+
+func TestMainMenuStartGame(t *testing.T) {
+	g := NewGame()
+	g.phase = PhaseMenu
+	g.mainMenu = NewMainMenu()
+	inp := &menuInput{enter: true}
+	g.input = inp
+	g.lastUpdate = time.Now()
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if g.phase != PhasePlaying {
+		t.Fatalf("expected PhasePlaying, got %v", g.phase)
+	}
+}
+
+func TestMainMenuCursorWrap(t *testing.T) {
+	g := NewGame()
+	g.phase = PhaseMenu
+	g.mainMenu = NewMainMenu()
+	inp := &menuInput{up: true}
+	g.input = inp
+	g.lastUpdate = time.Now()
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if g.mainMenu.cursor != len(g.mainMenu.options)-1 {
+		t.Fatalf("expected cursor wrap, got %d", g.mainMenu.cursor)
+	}
+}
+
+func TestMainMenuSettingsToggle(t *testing.T) {
+	g := NewGame()
+	g.phase = PhaseMenu
+	g.mainMenu = NewMainMenu()
+	g.mainMenu.cursor = 1
+	inp := &menuInput{enter: true}
+	g.input = inp
+	g.lastUpdate = time.Now()
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if !g.mainMenu.inSettings {
+		t.Fatalf("expected settings menu open")
+	}
+	inp.enter = true
+	g.mainMenu.settingsCursor = 0
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if !g.settings.Mute {
+		t.Fatalf("expected mute toggled")
+	}
+}

--- a/v1/internal/game/sound.go
+++ b/v1/internal/game/sound.go
@@ -22,13 +22,35 @@ func getAudioContext() *audio.Context {
 
 // SoundManager handles basic sound effects and music.
 type SoundManager struct {
-	ctx  *audio.Context
-	mute bool
+	ctx   *audio.Context
+	mute  bool
+	music *audio.Player
 }
 
 // NewSoundManager creates a SoundManager with an audio context.
 func NewSoundManager() *SoundManager {
 	return &SoundManager{ctx: getAudioContext()}
+}
+
+// StartMusic begins a simple looping tone for the title screen.
+func (s *SoundManager) StartMusic() {
+	if s == nil || s.mute || s.music != nil {
+		return
+	}
+	buf := generateSineWave(110, 0.5)
+	loop := audio.NewInfiniteLoop(bytes.NewReader(buf), sampleRate/2)
+	p, _ := s.ctx.NewPlayer(loop)
+	p.Play()
+	s.music = p
+}
+
+// StopMusic stops any playing music.
+func (s *SoundManager) StopMusic() {
+	if s == nil || s.music == nil {
+		return
+	}
+	s.music.Close()
+	s.music = nil
 }
 
 // ToggleMute enables or disables all sound output.

--- a/v1/internal/game/state.go
+++ b/v1/internal/game/state.go
@@ -1,0 +1,9 @@
+package game
+
+// GamePhase represents high level game states.
+type GamePhase int
+
+const (
+	PhaseMenu GamePhase = iota
+	PhasePlaying
+)


### PR DESCRIPTION
## Summary
- add main menu state and scrolling background
- play looping music on the title screen
- integrate new state into game loop
- update docs and requirements
- cover new menu logic with tests

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: forbidden module download)*

------
https://chatgpt.com/codex/tasks/task_e_684198d71cfc8327b9a54b2ea97c3dd3