### PR TITLE
Implement HUD resource icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ See the [ROADMAP.md](./ROADMAP.md) for detailed tasks.
 - Typing the generated word spawns a Footman unit.
 - Spawned units are tracked by the new `Military` system.
 - Word generation logic and cooldown behavior are tested in `barracks_test.go`.
-- HUD now shows cooldown progress bars for the Farmer and Barracks.
+ - HUD now shows cooldown progress bars for the Farmer and Barracks.
+ - HUD also displays resource icons for Gold, Wood, Stone, Iron and Mana.
 - Press `/` to label towers with letters and open an upgrade menu for the chosen tower.
 - Press `:` to enter command mode for quick text commands like `pause` or `quit`.
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -118,6 +118,7 @@ All new features are optional enhancements, preserving the educational and acces
 | **UI-NAV-4** | Hot-reload config `F5`. |
 | **UI-NAV-5** | Key-rebinder supports QWERTY, Colemak, Dvorak. |
 | **UI-BUILD-1** | HUD displays cooldown progress for Farmer and Barracks. |
+| **UI-RES-1** | HUD shows resource icons for Gold, Wood, Stone, Iron and Mana. |
 | **UI-TITLE-1** | Game starts at a title screen with Start, Settings and Quit options. |
 | **UI-TITLE-2** | Title screen has a simple animated background and is keyboard navigable. |
 | **UI-PREGAME-1** | Pre-game setup screen handles character and difficulty selection, tutorial, typing test and mode selection. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,10 +36,10 @@
 
 ## Resource Loop & HUD
 
-- [ ] **R-001** Implement Gold/Wood/Stone/Iron structs
-- [ ] **R-002** Farmer, Lumberjack, Miner cooldowns produce resources
-  - [ ] Balance numbers in `config.json`
-- [ ] **HUD-001** Top bar resource icons (`G`, `W`, `S`, `I`, `M`)
+- [x] **R-001** Implement Gold/Wood/Stone/Iron structs
+- [x] **R-002** Farmer, Lumberjack, Miner cooldowns produce resources
+  - [x] Balance numbers in `config.json`
+- [x] **HUD-001** Top bar resource icons (`G`, `W`, `S`, `I`, `M`)
 - [ ] **HUD-002** Show word processing queue with conveyor belt animation
 - [ ] **HUD-003** Tower selection overlay with letter labels
 - [ ] **TEST-RES** Integration test 3 min sim, resources > 0

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -3,6 +3,7 @@ package game
 import (
 	"fmt"
 	"image/color"
+	"strconv"
 	"strings"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -35,18 +36,42 @@ func NewHUD(g *Game) *HUD {
 	return &HUD{game: g}
 }
 
-// drawResources renders a simple resource bar at the top left.
-func (h *HUD) drawResources(screen *ebiten.Image) {
-	gold := h.game.resources.GoldAmount()
-	wood := h.game.resources.WoodAmount()
-	stone := h.game.resources.StoneAmount()
-	iron := h.game.resources.IronAmount()
-	mana := 0
-	textStr := fmt.Sprintf("G:%d W:%d S:%d I:%d M:%d", gold, wood, stone, iron, mana)
-	opts := &text.DrawOptions{}
-	opts.GeoM.Translate(10, 10)
-	opts.ColorScale.ScaleWithColor(color.White)
-	text.Draw(screen, textStr, BoldFont, opts)
+// drawResourceIcons renders resource amounts as letter icons at the top left.
+func (h *HUD) drawResourceIcons(screen *ebiten.Image) {
+	type icon struct {
+		label  string
+		amount int
+		clr    color.RGBA
+	}
+
+	icons := []icon{
+		{"G", h.game.resources.GoldAmount(), color.RGBA{255, 215, 0, 255}},
+		{"W", h.game.resources.WoodAmount(), color.RGBA{139, 69, 19, 255}},
+		{"S", h.game.resources.StoneAmount(), color.RGBA{128, 128, 128, 255}},
+		{"I", h.game.resources.IronAmount(), color.RGBA{169, 169, 169, 255}},
+		{"M", 0, color.RGBA{75, 0, 130, 255}},
+	}
+
+	size := 20.0
+	x := 10.0
+	y := 10.0
+
+	for _, ic := range icons {
+		vector.DrawFilledRect(screen, float32(x), float32(y), float32(size), float32(size), ic.clr, false)
+
+		opts := &text.DrawOptions{}
+		opts.GeoM.Translate(x+4, y+4)
+		opts.ColorScale.ScaleWithColor(color.Black)
+		text.Draw(screen, ic.label, BoldFont, opts)
+
+		numStr := strconv.Itoa(ic.amount)
+		opts = &text.DrawOptions{}
+		opts.GeoM.Translate(x+size+4, y+14)
+		opts.ColorScale.ScaleWithColor(color.White)
+		text.Draw(screen, numStr, BoldFont, opts)
+
+		x += size + float64(len(numStr))*13.0 + 16
+	}
 }
 
 // drawQueue renders the global typing queue at the top center of the screen.
@@ -86,7 +111,7 @@ func (h *HUD) drawQueue(screen *ebiten.Image) {
 
 // Draw renders ammo count, tower stats, reload prompts, and shop interface.
 func (h *HUD) Draw(screen *ebiten.Image) {
-	h.drawResources(screen)
+	h.drawResourceIcons(screen)
 	h.drawQueue(screen)
 	if h.game.commandMode {
 		drawMenu(screen, []string{":" + h.game.commandBuffer}, 860, 1020)


### PR DESCRIPTION
## Summary
- show top-bar resource icons in HUD
- document new feature in README and REQUIREMENTS
- mark resource tasks complete in ROADMAP

## Testing
- `gofmt -w v1/internal/game/hud.go`
- `GOTOOLCHAIN=local go vet ./...` *(fails: Get "https://proxy.golang.org/github.com/hajimehoshi/ebiten/v2/...": Forbidden)*
- `GOTOOLCHAIN=local go test ./...` *(fails: Get "https://proxy.golang.org/github.com/hajimehoshi/ebiten/v2/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841a1fbba8083279cec9a075e774b8f