### PR TITLE
Implement HUD queue conveyor animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ go test -tags test ./...
 -## Current prototype
 
 - Shared FIFO queue manager implemented. Buildings enqueue words that are processed **letter by letter**. Completing a Barracks word spawns a Footman.
-- Global queue is rendered at `(400,900)` with a simple conveyor animation. Mistypes jam the queue until Backspace is pressed.
+- Global queue is displayed on the HUD at `(400,900)` with a conveyor belt animation. Mistypes jam the queue until Backspace is pressed.
 - Mistypes now trigger a brief red flash and a "clank" sound effect.
 - Basic orc grunt waves scale every 45 s.
  - Back-pressure damage: if the queue grows past 20 letters, the base loses 1 HP each second.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -119,6 +119,7 @@ All new features are optional enhancements, preserving the educational and acces
 | **UI-NAV-5** | Key-rebinder supports QWERTY, Colemak, Dvorak. |
 | **UI-BUILD-1** | HUD displays cooldown progress for Farmer and Barracks. |
 | **UI-RES-1** | HUD shows resource icons for Gold, Wood, Stone, Iron and Mana. |
+| **UI-QUEUE-1** | HUD displays the word queue with a conveyor belt animation. |
 | **UI-TITLE-1** | Game starts at a title screen with Start, Settings and Quit options. |
 | **UI-TITLE-2** | Title screen has a simple animated background and is keyboard navigable. |
 | **UI-PREGAME-1** | Pre-game setup screen handles character and difficulty selection, tutorial, typing test and mode selection. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@
 - [x] **R-002** Farmer, Lumberjack, Miner cooldowns produce resources
   - [x] Balance numbers in `config.json`
 - [x] **HUD-001** Top bar resource icons (`G`, `W`, `S`, `I`, `M`)
-- [ ] **HUD-002** Show word processing queue with conveyor belt animation
+- [x] **HUD-002** Show word processing queue with conveyor belt animation
 - [ ] **HUD-003** Tower selection overlay with letter labels
 - [ ] **TEST-RES** Integration test 3 min sim, resources > 0
 

--- a/v1/internal/game/conveyor_animation_test.go
+++ b/v1/internal/game/conveyor_animation_test.go
@@ -1,0 +1,46 @@
+package game
+
+import "testing"
+
+// stubInput for deterministic input
+type stubInputConveyor struct{ typed []rune }
+
+func (s *stubInputConveyor) TypedChars() []rune { return s.typed }
+func (s *stubInputConveyor) Update()            {}
+func (s *stubInputConveyor) Reset()             { s.typed = nil }
+func (s *stubInputConveyor) Backspace() bool    { return false }
+func (s *stubInputConveyor) Space() bool        { return false }
+func (s *stubInputConveyor) Quit() bool         { return false }
+func (s *stubInputConveyor) Reload() bool       { return false }
+func (s *stubInputConveyor) Enter() bool        { return false }
+func (s *stubInputConveyor) Left() bool         { return false }
+func (s *stubInputConveyor) Right() bool        { return false }
+func (s *stubInputConveyor) Up() bool           { return false }
+func (s *stubInputConveyor) Down() bool         { return false }
+func (s *stubInputConveyor) Build() bool        { return false }
+func (s *stubInputConveyor) Save() bool         { return false }
+func (s *stubInputConveyor) Load() bool         { return false }
+func (s *stubInputConveyor) Command() bool      { return false }
+
+func TestConveyorOffsetMoves(t *testing.T) {
+	g := NewGame()
+	inp := &stubInputConveyor{}
+	g.input = inp
+	g.Queue().Enqueue(Word{Text: "ab"})
+
+	inp.typed = []rune{'a'}
+	g.Step(0.1)
+	if g.conveyorOffset <= 0 {
+		t.Fatalf("expected offset to increase after typing")
+	}
+	off := g.conveyorOffset
+
+	inp.typed = nil
+	// simulate 1 second to let offset decay
+	for i := 0; i < 60; i++ {
+		g.Step(1.0 / 60.0)
+	}
+	if g.conveyorOffset >= off {
+		t.Fatalf("expected offset to decrease over time")
+	}
+}

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -3,6 +3,7 @@ package game
 import (
 	"fmt"
 	"image/color"
+	"math"
 	"strconv"
 	"strings"
 
@@ -34,6 +35,30 @@ func progressBar(progress float64, width int) string {
 // NewHUD creates a new HUD bound to the given game.
 func NewHUD(g *Game) *HUD {
 	return &HUD{game: g}
+}
+
+// drawConveyorBelt renders a simple conveyor belt animation behind the queue.
+// totalWidth is the total width of the queued words to ensure the belt spans
+// the text. Slanted stripes move with the conveyor offset to give an illusion
+// of motion.
+func (h *HUD) drawConveyorBelt(screen *ebiten.Image, totalWidth float64) {
+	beltHeight := 24.0
+	beltY := h.game.wordProcessY - 18
+	beltX := h.game.wordProcessX - h.game.conveyorOffset - 10
+	beltW := totalWidth + 20
+
+	// Draw base belt rectangle
+	vector.DrawFilledRect(screen, float32(beltX), float32(beltY), float32(beltW), float32(beltHeight), color.RGBA{50, 50, 50, 180}, false)
+
+	// Draw slanted stripes to indicate movement
+	stripeSpacing := 12.0
+	offset := math.Mod(h.game.conveyorOffset, stripeSpacing)
+	for x := -offset; x < beltW; x += stripeSpacing {
+		vector.DrawLine(screen,
+			float32(beltX+x), float32(beltY),
+			float32(beltX+x+beltHeight/2), float32(beltY+beltHeight),
+			1, color.RGBA{80, 80, 80, 200}, false)
+	}
 }
 
 // drawResourceIcons renders resource amounts as letter icons at the top left.
@@ -90,6 +115,7 @@ func (h *HUD) drawQueue(screen *ebiten.Image) {
 		total += float64(len(w.Text))*13.0 + spacing
 	}
 	total -= spacing
+	h.drawConveyorBelt(screen, total)
 	x := h.game.wordProcessX - h.game.conveyorOffset
 	y := h.game.wordProcessY
 


### PR DESCRIPTION
## Summary
- draw an animated conveyor belt for the word queue
- test conveyor offset behaviour
- update README with HUD queue info
- tick HUD-002 in ROADMAP
- document UI-QUEUE-1 requirement

## Testing
- `go test ./...` *(fails: access to Go toolchain blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6841a37aec4483278428a43d3a09b9a8