### PR TITLE
Implement HUD-003 tower selection overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See the [ROADMAP.md](./ROADMAP.md) for detailed tasks.
 - Word generation logic and cooldown behavior are tested in `barracks_test.go`.
  - HUD now shows cooldown progress bars for the Farmer and Barracks.
  - HUD also displays resource icons for Gold, Wood, Stone, Iron and Mana.
-- Press `/` to label towers with letters and open an upgrade menu for the chosen tower.
+ - Press `/` to enter tower selection mode. The screen dims and towers are labeled with letters; press a letter to open that tower's upgrade menu.
 - Press `:` to enter command mode for quick text commands like `pause` or `quit`.
 
 See docs/REQUIREMENTS.md for the full feature scaffold, ROADMAP.md for planned phases, and TODO.md for sprint tasks.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -124,6 +124,7 @@ All new features are optional enhancements, preserving the educational and acces
 | **UI-TITLE-2** | Title screen has a simple animated background and is keyboard navigable. |
 | **UI-PREGAME-1** | Pre-game setup screen handles character and difficulty selection, tutorial, typing test and mode selection. |
 | **UI-TOWER-1** | `/` enters tower selection mode, labels towers with letters and opens an upgrade menu for the chosen tower. |
+| **UI-TOWER-2** | Tower selection mode dims the background and displays letter labels above towers. |
 | **UI-CMD-1** | `:` enters command mode allowing text commands like `pause` or `quit`. |
 
 *Planned: Typed commands for minion management, skill tree navigation, and minigames. All new features remain keyboard-only.*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@
   - [x] Balance numbers in `config.json`
 - [x] **HUD-001** Top bar resource icons (`G`, `W`, `S`, `I`, `M`)
 - [x] **HUD-002** Show word processing queue with conveyor belt animation
-- [ ] **HUD-003** Tower selection overlay with letter labels
+- [x] **HUD-003** Tower selection overlay with letter labels
 - [ ] **TEST-RES** Integration test 3 min sim, resources > 0
 
 ---

--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -856,7 +856,12 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			bx, by, bw, bh := t.Bounds()
 			vector.StrokeRect(g.screen, float32(bx-2), float32(by-2), float32(bw+4), float32(bh+4), 2, color.RGBA{255, 0, 0, 200}, false)
 		}
-		if g.towerSelectMode {
+	}
+
+	if g.towerSelectMode {
+		// Dim the background to highlight tower labels
+		vector.DrawFilledRect(g.screen, 0, 0, 1920, 1080, color.RGBA{0, 0, 0, 120}, false)
+		for i, t := range g.towers {
 			label := ""
 			for k, idx := range g.towerLabels {
 				if idx == i {
@@ -865,8 +870,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				}
 			}
 			if label != "" {
+				x, y := t.Position()
 				opts := &text.DrawOptions{}
-				opts.GeoM.Translate(float64(t.pos.X)-6, float64(t.pos.Y)-30)
+				opts.GeoM.Translate(x-6, y-30)
 				opts.ColorScale.ScaleWithColor(color.White)
 				text.Draw(g.screen, label, BoldFont, opts)
 			}

--- a/v1/internal/game/tower_select_test.go
+++ b/v1/internal/game/tower_select_test.go
@@ -52,3 +52,41 @@ func TestSelectTowerOpensUpgrade(t *testing.T) {
 		t.Errorf("expected tower 1 selected got %d", g.selectedTower)
 	}
 }
+
+type stubInputSelect struct{ selectTower bool }
+
+func (s *stubInputSelect) TypedChars() []rune { return nil }
+func (s *stubInputSelect) Update()            {}
+func (s *stubInputSelect) Reset()             { s.selectTower = false }
+func (s *stubInputSelect) Backspace() bool    { return false }
+func (s *stubInputSelect) Space() bool        { return false }
+func (s *stubInputSelect) Quit() bool         { return false }
+func (s *stubInputSelect) Reload() bool       { return false }
+func (s *stubInputSelect) Enter() bool        { return false }
+func (s *stubInputSelect) Left() bool         { return false }
+func (s *stubInputSelect) Right() bool        { return false }
+func (s *stubInputSelect) Up() bool           { return false }
+func (s *stubInputSelect) Down() bool         { return false }
+func (s *stubInputSelect) Build() bool        { return false }
+func (s *stubInputSelect) Save() bool         { return false }
+func (s *stubInputSelect) Load() bool         { return false }
+func (s *stubInputSelect) SelectTower() bool  { v := s.selectTower; s.selectTower = false; return v }
+func (s *stubInputSelect) Command() bool      { return false }
+
+func TestSlashOpensTowerSelect(t *testing.T) {
+	g := NewGame()
+	g.phase = PhasePlaying
+	g.towers = []*Tower{NewTower(g, 0, 0)}
+	inp := &stubInputSelect{selectTower: true}
+	g.input = inp
+	g.lastUpdate = time.Now()
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if !g.towerSelectMode {
+		t.Fatalf("expected tower selection mode to activate")
+	}
+	if len(g.towerLabels) == 0 {
+		t.Fatalf("labels should be assigned when selection mode starts")
+	}
+}


### PR DESCRIPTION
## Summary
- add dim overlay and label drawing for tower selection
- test activating tower select via `/`
- document tower selection overlay feature
- add UI requirement for overlay
- mark HUD-003 done in roadmap

## Testing
- `go test ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_6841a514f2c8832790ead75094ad0d94