### PR TITLE
Implement YAML tech tree parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,15 @@ for three minutes and verifies that all resources accumulate from zero.
 - Pre-game setup lets you choose a character and difficulty, shows a quick
   tutorial and typing test, then prompts for mode selection.
 - Letter unlock order and costs documented (see `docs/LETTER_UNLOCKS.md`).
-- Letters can now be unlocked in-game using King's Points, expanding each building's word pool.
-- Tech trees are defined in YAML under `data/trees/` (see `letters_basic.yaml`).
+ - Letters can now be unlocked in-game using King's Points, expanding each building's word pool.
+ - Tech trees are defined in YAML under `data/trees/` (see `letters_basic.yaml`). They are loaded at runtime via a Go parser that builds an in-memory graph and verifies all prerequisites.
 
 ## Tech Tree YAML
 
 Tech tree files live in `data/trees/` and describe upgrade nodes. The example
 `letters_basic.yaml` shows the schema with fields for `type`, `cost`, `effects`
-and `prereqs`.
+and `prereqs`. The `LoadTechTree` function parses these YAML files and returns a
+validated in-memory graph.
 
 ---
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -103,6 +103,8 @@ All new features are optional enhancements, preserving the educational and acces
 - **TREE-2** Node types: `UnlockLetter`, `StatBoost`, `NewUnit`, `CDReduction`, `GlobalPassive`.  
 - **TREE-3** Infinite spiral: on outer-ring completion, costs×2, effects×1.1.
 - **TREE-4** Each YAML node defines `type`, `cost`, `effects`, and `prereqs` fields.
+- **TREE-5** Tech trees are loaded at runtime from YAML via `LoadTechTree`.
+- **TREE-6** The loader validates graphs, rejecting cycles or missing prerequisites.
 
 *Planned: Skill tree expands to 100+ nodes, with branches for offense, defense, typing proficiency, automation, and utility. Certain nodes require WPM/accuracy milestones.*
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,13 +53,13 @@
 
 ## Tech Tree & Progression
 
-- [ ] **T-002** Tech tree parser + in-memory graph
-  - [ ] **T-002.1** Define Go structs matching YAML schema (TechNode, TechTree, effects/prereqs)
-  - [ ] **T-002.2** Implement YAML loader in Go (use yaml.v2)
-  - [ ] **T-002.3** Validate tech graph (detect cycles, missing prereqs)
-  - [ ] **T-002.4** Build in-memory graph (nodes by ID, adjacency)
-  - [ ] **T-002.5** Expose graph API (GetPrerequisites, UnlockOrder)
-  - [ ] **T-002.6** Write unit tests for parser and validation
+- [x] **T-002** Tech tree parser + in-memory graph
+  - [x] **T-002.1** Define Go structs matching YAML schema (TechNode, TechTree, effects/prereqs)
+  - [x] **T-002.2** Implement YAML loader in Go (use yaml.v2)
+  - [x] **T-002.3** Validate tech graph (detect cycles, missing prereqs)
+  - [x] **T-002.4** Build in-memory graph (nodes by ID, adjacency)
+  - [x] **T-002.5** Expose graph API (GetPrerequisites, UnlockOrder)
+  - [x] **T-002.6** Write unit tests for parser and validation
 - [ ] **T-003** Keyboard UI for tech purchase (`/` search, `Enter` buy)
   - [ ] **T-003.1** Add `techMenuOpen`, `searchBuffer`, and selection index fields to `Game`
   - [ ] **T-003.2** Capture `/` key in `Input.Update` to toggle tech menu mode

--- a/v1/go.mod
+++ b/v1/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.23.9
 
 require github.com/hajimehoshi/ebiten/v2 v2.8.8
+require gopkg.in/yaml.v2 v2.4.0
 
 require (
 	github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 // indirect

--- a/v1/internal/game/tech_tree.go
+++ b/v1/internal/game/tech_tree.go
@@ -1,0 +1,113 @@
+package game
+
+import (
+	"fmt"
+	"os"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+// NodeEffects describes modifiers granted by a tech node.
+type NodeEffects struct {
+	Letters    []string `yaml:"letters"`
+	RangeMult  float64  `yaml:"range_mult"`
+	DamageMult float64  `yaml:"damage_mult"`
+	AmmoAdd    int      `yaml:"ammo_add"`
+}
+
+// TechNode represents a node in the tech tree YAML.
+type TechNode struct {
+	ID      string      `yaml:"id"`
+	Name    string      `yaml:"name"`
+	Type    string      `yaml:"type"`
+	Cost    int         `yaml:"cost"`
+	Effects NodeEffects `yaml:"effects"`
+	Prereqs []string    `yaml:"prereqs"`
+}
+
+type techFile struct {
+	Nodes []TechNode `yaml:"nodes"`
+}
+
+// TechTree is an in-memory graph of technology nodes.
+type TechTree struct {
+	Nodes map[string]*TechNode
+	order []string
+}
+
+// LoadTechTree parses a YAML file into a TechTree and validates it.
+func LoadTechTree(path string) (*TechTree, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var f techFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, err
+	}
+	tree := &TechTree{Nodes: map[string]*TechNode{}}
+	for i := range f.Nodes {
+		n := f.Nodes[i]
+		tree.Nodes[n.ID] = &n
+	}
+	if err := tree.validate(); err != nil {
+		return nil, err
+	}
+	return tree, nil
+}
+
+// GetPrerequisites returns the prerequisite IDs for a node.
+func (t *TechTree) GetPrerequisites(id string) []string {
+	if n, ok := t.Nodes[id]; ok {
+		return append([]string(nil), n.Prereqs...)
+	}
+	return nil
+}
+
+// UnlockOrder returns a topological order of node IDs.
+func (t *TechTree) UnlockOrder() []string {
+	return append([]string(nil), t.order...)
+}
+
+// validate checks for missing prereqs and cycles and builds UnlockOrder.
+func (t *TechTree) validate() error {
+	for id, n := range t.Nodes {
+		for _, p := range n.Prereqs {
+			if _, ok := t.Nodes[p]; !ok {
+				return fmt.Errorf("node %s missing prereq %s", id, p)
+			}
+		}
+	}
+	visited := map[string]bool{}
+	stack := map[string]bool{}
+	t.order = nil
+	var visit func(string) error
+	visit = func(id string) error {
+		if stack[id] {
+			return fmt.Errorf("cycle detected at %s", id)
+		}
+		if visited[id] {
+			return nil
+		}
+		stack[id] = true
+		for _, p := range t.Nodes[id].Prereqs {
+			if err := visit(p); err != nil {
+				return err
+			}
+		}
+		stack[id] = false
+		visited[id] = true
+		t.order = append(t.order, id)
+		return nil
+	}
+	for id := range t.Nodes {
+		if err := visit(id); err != nil {
+			return err
+		}
+	}
+	// reverse order so prerequisites appear first
+	for i, j := 0, len(t.order)-1; i < j; i, j = i+1, j-1 {
+		t.order[i], t.order[j] = t.order[j], t.order[i]
+	}
+	return nil
+}

--- a/v1/internal/game/tech_tree_test.go
+++ b/v1/internal/game/tech_tree_test.go
@@ -1,0 +1,69 @@
+package game
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadTechTree(t *testing.T) {
+	path := "../../data/trees/letters_basic.yaml"
+	tree, err := LoadTechTree(path)
+	if err != nil {
+		t.Fatalf("load tech tree: %v", err)
+	}
+	if len(tree.Nodes) != 4 {
+		t.Fatalf("expected 4 nodes got %d", len(tree.Nodes))
+	}
+	node, ok := tree.Nodes["index_ext"]
+	if !ok {
+		t.Fatalf("missing node index_ext")
+	}
+	if node.Cost != 20 {
+		t.Fatalf("expected cost 20 got %d", node.Cost)
+	}
+}
+
+func TestValidateCycle(t *testing.T) {
+	yaml := `nodes:
+  - id: a
+    name: A
+    type: UnlockLetter
+    cost: 0
+    prereqs: [b]
+  - id: b
+    name: B
+    type: UnlockLetter
+    cost: 0
+    prereqs: [a]
+`
+	tmp, err := os.CreateTemp("", "cycle*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write([]byte(yaml)); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if _, err := LoadTechTree(tmp.Name()); err == nil {
+		t.Fatalf("expected cycle error")
+	}
+}
+
+func TestUnlockOrder(t *testing.T) {
+	path := "../../data/trees/letters_basic.yaml"
+	tree, err := LoadTechTree(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	order := tree.UnlockOrder()
+	expected := []string{"home_row", "index_ext", "middle_fingers", "ring_finger"}
+	if len(order) != len(expected) {
+		t.Fatalf("unexpected order length %v", order)
+	}
+	for i, id := range expected {
+		if order[i] != id {
+			t.Fatalf("expected %s at %d got %s", id, i, order[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- load tech tree definitions from YAML via `LoadTechTree`
- validate graphs to detect missing prerequisites or cycles
- expose `GetPrerequisites` and `UnlockOrder` APIs
- add unit tests for loader and validation
- document runtime tech tree loading
- mark roadmap tasks complete
- add requirements for tech tree parser
- add yaml dependency to go.mod

## Testing
- `go mod tidy` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841aabfc29083278d9c56b98aa347a2