### PR TITLE
Implement skill tree struct scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All new features remain optional enhancements on top of the base game, ensuring 
 | **Incremental & Idle Mechanics** | Optional idle progression: auto-collection, offline progress, auto-reloading towers, and upgradable generators allow for meaningful progress with minimal input. Prestige/reset mechanics extend replayability. |
 | **Typing Minigames & Challenges** | Speed trials, accuracy challenges, word puzzles, and boss practice modes provide fun breaks, reinforce typing skills, and grant in-game rewards. |
 | **Multiple Playstyle Support** | Grind, optimize, idle, or embrace chaos—each playstyle is valid and rewarding, with systems and skill tree branches to support them. |
+| **Global Skill Tree Foundations** | Structs define offense, defense, typing, automation and utility categories for upcoming upgrades. |
 | **Pixel-art Charm** | SNES-style sprites & slap-stick combat (exploding cabbages, bouncing arrows, comic “BONK!” bubbles). Violence stays E10+ but feels impactful. |
 
 ---

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -108,6 +108,9 @@ All new features are optional enhancements, preserving the educational and acces
 
 *Planned: Skill tree expands to 100+ nodes, with branches for offense, defense, typing proficiency, automation, and utility. Certain nodes require WPM/accuracy milestones.*
 
+- **SKILL-1** The global skill tree organizes nodes into Offense, Defense, Typing, Automation, and Utility categories.
+- **SKILL-2** Go structs `SkillCategory`, `SkillNode`, and `SkillTree` define the skill tree in memory.
+
 ---
 
 ## 6 UI / Input

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@
   - [x] **T-003.7** Handle `Enter` key to purchase selected tech: check prerequisites/resources, call `UnlockNext`
   - [x] **T-003.8** Write unit tests for tech menu: toggling, filtering, navigation, and purchase flow
 - [ ] **SKILL-001** Global skill tree UI (offense, defense, typing, automation, utility)
-  - [ ] **SKILL-001.1** Define Go structs for skill tree nodes and categories (offense, defense, typing, automation, utility)
+  - [x] **SKILL-001.1** Define Go structs for skill tree nodes and categories (offense, defense, typing, automation, utility)
   - [ ] **SKILL-001.2** Implement in-memory skill tree structure and sample data
   - [ ] **SKILL-001.3** Add keyboard UI: open skill tree menu, navigate categories/nodes, show node details
   - [ ] **SKILL-001.4** Render skill tree overlay: display branches, highlight selected node, show unlock status

--- a/v1/internal/game/skill_tree.go
+++ b/v1/internal/game/skill_tree.go
@@ -1,0 +1,27 @@
+package game
+
+// SkillCategory is the high level grouping for a skill tree node.
+type SkillCategory int
+
+const (
+	SkillOffense SkillCategory = iota
+	SkillDefense
+	SkillTyping
+	SkillAutomation
+	SkillUtility
+)
+
+// SkillNode represents a single unlockable skill in the global skill tree.
+type SkillNode struct {
+	ID       string
+	Name     string
+	Category SkillCategory
+	Cost     int
+	Effects  map[string]float64
+	Prereqs  []string
+}
+
+// SkillTree holds all skill nodes keyed by ID.
+type SkillTree struct {
+	Nodes map[string]*SkillNode
+}


### PR DESCRIPTION
## Summary
- define SkillCategory enum and basic SkillNode/SkillTree structs
- document global skill tree categories in README and REQUIREMENTS
- mark roadmap task SKILL-001.1 complete

## Testing
- `go test ./...` *(fails: forbidden toolchain download)*

------
https://chatgpt.com/codex/tasks/task_e_6841bfe1fe7883278ca944549932e1b6