### PR TITLE
Implement sample SkillTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All new features remain optional enhancements on top of the base game, ensuring 
 | **Incremental & Idle Mechanics** | Optional idle progression: auto-collection, offline progress, auto-reloading towers, and upgradable generators allow for meaningful progress with minimal input. Prestige/reset mechanics extend replayability. |
 | **Typing Minigames & Challenges** | Speed trials, accuracy challenges, word puzzles, and boss practice modes provide fun breaks, reinforce typing skills, and grant in-game rewards. |
 | **Multiple Playstyle Support** | Grind, optimize, idle, or embrace chaos—each playstyle is valid and rewarding, with systems and skill tree branches to support them. |
-| **Global Skill Tree Foundations** | Structs define offense, defense, typing, automation and utility categories for upcoming upgrades. |
+| **Global Skill Tree** | Sample in-memory tree defines offense, defense, typing, automation and utility nodes. |
 | **Pixel-art Charm** | SNES-style sprites & slap-stick combat (exploding cabbages, bouncing arrows, comic “BONK!” bubbles). Violence stays E10+ but feels impactful. |
 
 ---

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -110,6 +110,7 @@ All new features are optional enhancements, preserving the educational and acces
 
 - **SKILL-1** The global skill tree organizes nodes into Offense, Defense, Typing, Automation, and Utility categories.
 - **SKILL-2** Go structs `SkillCategory`, `SkillNode`, and `SkillTree` define the skill tree in memory.
+- **SKILL-3** `SampleSkillTree` provides a validated in-memory tree with example nodes for each category.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,7 +71,7 @@
   - [x] **T-003.8** Write unit tests for tech menu: toggling, filtering, navigation, and purchase flow
 - [ ] **SKILL-001** Global skill tree UI (offense, defense, typing, automation, utility)
   - [x] **SKILL-001.1** Define Go structs for skill tree nodes and categories (offense, defense, typing, automation, utility)
-  - [ ] **SKILL-001.2** Implement in-memory skill tree structure and sample data
+  - [x] **SKILL-001.2** Implement in-memory skill tree structure and sample data
   - [ ] **SKILL-001.3** Add keyboard UI: open skill tree menu, navigate categories/nodes, show node details
   - [ ] **SKILL-001.4** Render skill tree overlay: display branches, highlight selected node, show unlock status
   - [ ] **SKILL-001.5** Implement skill unlock logic: check prerequisites/resources, update state on unlock

--- a/v1/internal/game/skill_tree.go
+++ b/v1/internal/game/skill_tree.go
@@ -1,5 +1,7 @@
 package game
 
+import "fmt"
+
 // SkillCategory is the high level grouping for a skill tree node.
 type SkillCategory int
 
@@ -24,4 +26,119 @@ type SkillNode struct {
 // SkillTree holds all skill nodes keyed by ID.
 type SkillTree struct {
 	Nodes map[string]*SkillNode
+	order []string
+}
+
+// GetPrerequisites returns the prerequisite IDs for a given node.
+func (t *SkillTree) GetPrerequisites(id string) []string {
+	if n, ok := t.Nodes[id]; ok {
+		return append([]string(nil), n.Prereqs...)
+	}
+	return nil
+}
+
+// UnlockOrder returns a topological order of node IDs based on prerequisites.
+func (t *SkillTree) UnlockOrder() []string {
+	return append([]string(nil), t.order...)
+}
+
+func (t *SkillTree) validate() error {
+	for id, n := range t.Nodes {
+		for _, p := range n.Prereqs {
+			if _, ok := t.Nodes[p]; !ok {
+				return fmt.Errorf("node %s missing prereq %s", id, p)
+			}
+		}
+	}
+	visited := map[string]bool{}
+	stack := map[string]bool{}
+	t.order = nil
+	var visit func(string) error
+	visit = func(id string) error {
+		if stack[id] {
+			return fmt.Errorf("cycle detected at %s", id)
+		}
+		if visited[id] {
+			return nil
+		}
+		stack[id] = true
+		for _, p := range t.Nodes[id].Prereqs {
+			if err := visit(p); err != nil {
+				return err
+			}
+		}
+		stack[id] = false
+		visited[id] = true
+		t.order = append(t.order, id)
+		return nil
+	}
+	for id := range t.Nodes {
+		if err := visit(id); err != nil {
+			return err
+		}
+	}
+	for i, j := 0, len(t.order)-1; i < j; i, j = i+1, j-1 {
+		t.order[i], t.order[j] = t.order[j], t.order[i]
+	}
+	return nil
+}
+
+// SampleSkillTree returns a small predefined skill tree used for tests and
+// early prototyping.
+func SampleSkillTree() (*SkillTree, error) {
+	nodes := []SkillNode{
+		{
+			ID:       "sharp_arrows",
+			Name:     "Sharp Arrows",
+			Category: SkillOffense,
+			Cost:     10,
+			Effects:  map[string]float64{"damage_mult": 1.1},
+		},
+		{
+			ID:       "rapid_fire",
+			Name:     "Rapid Fire",
+			Category: SkillOffense,
+			Cost:     20,
+			Effects:  map[string]float64{"fire_rate_mult": 0.9},
+			Prereqs:  []string{"sharp_arrows"},
+		},
+		{
+			ID:       "reinforced_walls",
+			Name:     "Reinforced Walls",
+			Category: SkillDefense,
+			Cost:     10,
+			Effects:  map[string]float64{"hp_add": 25},
+		},
+		{
+			ID:       "touch_typing",
+			Name:     "Touch Typing",
+			Category: SkillTyping,
+			Cost:     5,
+			Effects:  map[string]float64{"wpm_bonus": 5},
+		},
+		{
+			ID:       "auto_collect",
+			Name:     "Auto Collect",
+			Category: SkillAutomation,
+			Cost:     15,
+			Effects:  map[string]float64{"auto_collect": 1},
+			Prereqs:  []string{"touch_typing"},
+		},
+		{
+			ID:       "quick_commands",
+			Name:     "Quick Commands",
+			Category: SkillUtility,
+			Cost:     5,
+			Effects:  map[string]float64{"hotkeys": 1},
+		},
+	}
+	tree := &SkillTree{Nodes: map[string]*SkillNode{}}
+	for i := range nodes {
+		n := nodes[i]
+		tree.Nodes[n.ID] = &n
+	}
+	if err := tree.validate(); err != nil {
+		return nil, err
+	}
+	return tree, nil
 }

--- a/v1/internal/game/skill_tree_test.go
+++ b/v1/internal/game/skill_tree_test.go
@@ -1,0 +1,46 @@
+package game
+
+import "testing"
+
+func TestSampleSkillTree(t *testing.T) {
+	tree, err := SampleSkillTree()
+	if err != nil {
+		t.Fatalf("sample skill tree: %v", err)
+	}
+	if len(tree.Nodes) != 6 {
+		t.Fatalf("expected 6 nodes got %d", len(tree.Nodes))
+	}
+	order := tree.UnlockOrder()
+	if len(order) != 6 {
+		t.Fatalf("unexpected unlock order length %d", len(order))
+	}
+	// ensure prerequisite ordering
+	for i, id := range order {
+		if id == "rapid_fire" && i == 0 {
+			t.Fatalf("rapid_fire should come after sharp_arrows")
+		}
+		if id == "auto_collect" {
+			// touch_typing must appear before auto_collect
+			seen := false
+			for _, prev := range order[:i] {
+				if prev == "touch_typing" {
+					seen = true
+					break
+				}
+			}
+			if !seen {
+				t.Fatalf("auto_collect missing prereq before it")
+			}
+		}
+	}
+}
+
+func TestSkillTreeCycleDetect(t *testing.T) {
+	tree := &SkillTree{Nodes: map[string]*SkillNode{
+		"a": {ID: "a", Prereqs: []string{"b"}},
+		"b": {ID: "b", Prereqs: []string{"a"}},
+	}}
+	if err := tree.validate(); err == nil {
+		t.Fatalf("expected cycle error")
+	}
+}


### PR DESCRIPTION
## Summary
- provide sample skill tree implementation
- validate skill graph and expose unlock order API
- unit tests for skill tree
- mark SKILL-001.2 complete in ROADMAP
- document new requirement and update README

## Testing
- `go vet ./...` *(passes)*
- `go test ./... -tags headless` *(fails: Package alsa not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cd71004c83279a651138f0c6d162