### PR TITLE
Implement skill tree keyboard UI and overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ See the [ROADMAP.md](./ROADMAP.md) for detailed tasks.
 
 - Press `/` to enter tower selection mode. The screen dims and towers are labeled with letters; press a letter to open that tower's upgrade menu.
 - Press `/` again to open the tech menu. Type to search unlocked technologies and press `Enter` to purchase the highlighted upgrade.
+- Press `Tab` to open the global skill tree. Use arrow keys to change categories and highlight skills. Locked and unlocked skills are indicated.
 - Press `:` to enter command mode for quick text commands like `pause` or `quit`.
 
 See docs/REQUIREMENTS.md for the full feature scaffold, ROADMAP.md for planned phases, and TODO.md for sprint tasks.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -111,6 +111,7 @@ All new features are optional enhancements, preserving the educational and acces
 - **SKILL-1** The global skill tree organizes nodes into Offense, Defense, Typing, Automation, and Utility categories.
 - **SKILL-2** Go structs `SkillCategory`, `SkillNode`, and `SkillTree` define the skill tree in memory.
 - **SKILL-3** `SampleSkillTree` provides a validated in-memory tree with example nodes for each category.
+- **SKILL-4** `Tab` opens the skill tree menu. Arrow keys switch categories and navigate nodes, highlighting the current selection and showing locked/unlocked status.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,8 +72,8 @@
 - [ ] **SKILL-001** Global skill tree UI (offense, defense, typing, automation, utility)
   - [x] **SKILL-001.1** Define Go structs for skill tree nodes and categories (offense, defense, typing, automation, utility)
   - [x] **SKILL-001.2** Implement in-memory skill tree structure and sample data
-  - [ ] **SKILL-001.3** Add keyboard UI: open skill tree menu, navigate categories/nodes, show node details
-  - [ ] **SKILL-001.4** Render skill tree overlay: display branches, highlight selected node, show unlock status
+  - [x] **SKILL-001.3** Add keyboard UI: open skill tree menu, navigate categories/nodes, show node details
+  - [x] **SKILL-001.4** Render skill tree overlay: display branches, highlight selected node, show unlock status
   - [ ] **SKILL-001.5** Implement skill unlock logic: check prerequisites/resources, update state on unlock
   - [ ] **SKILL-001.6** Integrate skill effects with game systems (e.g., global stat boosts, automation unlocks)
   - [ ] **SKILL-001.7** Write unit tests for skill tree navigation, unlocks, and effect application

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -178,12 +178,37 @@ func (h *HUD) drawTechMenu(screen *ebiten.Image) {
 	drawMenu(screen, lines, 760, 300)
 }
 
+// drawSkillTreeOverlay renders the global skill tree when active.
+func (h *HUD) drawSkillTreeOverlay(screen *ebiten.Image) {
+	if !h.game.skillMenuOpen {
+		return
+	}
+	nodes := h.game.skillMenuNodes()
+	if nodes == nil {
+		nodes = h.game.skillTree.NodesByCategory(h.game.skillCategory)
+	}
+	lines := []string{fmt.Sprintf("-- SKILLS: %s --", h.game.skillCategory.String())}
+	for i, n := range nodes {
+		status := "Locked"
+		if h.game.unlockedSkills[n.ID] {
+			status = "Unlocked"
+		}
+		prefix := "  "
+		if i == h.game.skillCursor {
+			prefix = "> "
+		}
+		lines = append(lines, fmt.Sprintf("%s%s - %s", prefix, n.Name, status))
+	}
+	drawMenu(screen, lines, 760, 300)
+}
+
 // Draw renders ammo count, tower stats, reload prompts, and shop interface.
 func (h *HUD) Draw(screen *ebiten.Image) {
 	h.drawResourceIcons(screen)
 	h.drawQueue(screen)
 	h.drawTowerSelectionOverlay(screen)
 	h.drawTechMenu(screen)
+	h.drawSkillTreeOverlay(screen)
 	if h.game.commandMode {
 		drawMenu(screen, []string{":" + h.game.commandBuffer}, 860, 1020)
 		return

--- a/v1/internal/game/input.go
+++ b/v1/internal/game/input.go
@@ -23,6 +23,7 @@ type InputHandler interface {
 	Load() bool
 	SelectTower() bool // Add this method to the interface
 	TechMenu() bool    // Toggle tech menu mode
+	SkillMenu() bool   // Toggle skill tree menu
 	Command() bool     // Command reports if ':' was pressed to enter command mode
 }
 
@@ -42,6 +43,7 @@ type Input struct {
 	load        bool
 	selectTower bool
 	techMenu    bool
+	skillMenu   bool
 	command     bool // whether ':' was pressed this frame
 }
 
@@ -63,6 +65,7 @@ func NewInput() *Input {
 		load:        false,
 		selectTower: false,
 		techMenu:    false,
+		skillMenu:   false,
 		command:     false,
 	}
 }
@@ -97,6 +100,7 @@ func (i *Input) Update() {
 	pressedSlash := inpututil.IsKeyJustPressed(ebiten.KeySlash)
 	i.selectTower = pressedSlash
 	i.techMenu = pressedSlash
+	i.skillMenu = inpututil.IsKeyJustPressed(ebiten.KeyTab)
 }
 
 // Reset resets the Input state to its default values.
@@ -116,6 +120,7 @@ func (i *Input) Reset() {
 	i.load = false
 	i.selectTower = false
 	i.techMenu = false
+	i.skillMenu = false
 	i.command = false
 }
 
@@ -158,4 +163,5 @@ func (i *Input) Save() bool        { return i.save }
 func (i *Input) Load() bool        { return i.load }
 func (i *Input) SelectTower() bool { return i.selectTower }
 func (i *Input) TechMenu() bool    { return i.techMenu }
+func (i *Input) SkillMenu() bool   { return i.skillMenu }
 func (i *Input) Command() bool     { return i.command }

--- a/v1/internal/game/skill_menu_test.go
+++ b/v1/internal/game/skill_menu_test.go
@@ -1,0 +1,78 @@
+//go:build test
+
+package game
+
+import (
+	"testing"
+	"time"
+)
+
+type skillInput struct {
+	toggle                bool
+	up, down, left, right bool
+	enter                 bool
+}
+
+func (s *skillInput) TypedChars() []rune { return nil }
+func (s *skillInput) Update()            {}
+func (s *skillInput) Reset() {
+	s.toggle, s.up, s.down, s.left, s.right, s.enter = false, false, false, false, false, false
+}
+func (s *skillInput) Backspace() bool   { return false }
+func (s *skillInput) Space() bool       { return false }
+func (s *skillInput) Quit() bool        { return false }
+func (s *skillInput) Reload() bool      { return false }
+func (s *skillInput) Enter() bool       { v := s.enter; s.enter = false; return v }
+func (s *skillInput) Left() bool        { v := s.left; s.left = false; return v }
+func (s *skillInput) Right() bool       { v := s.right; s.right = false; return v }
+func (s *skillInput) Up() bool          { v := s.up; s.up = false; return v }
+func (s *skillInput) Down() bool        { v := s.down; s.down = false; return v }
+func (s *skillInput) Build() bool       { return false }
+func (s *skillInput) Save() bool        { return false }
+func (s *skillInput) Load() bool        { return false }
+func (s *skillInput) SelectTower() bool { return false }
+func (s *skillInput) TechMenu() bool    { return false }
+func (s *skillInput) SkillMenu() bool   { v := s.toggle; s.toggle = false; return v }
+func (s *skillInput) Command() bool     { return false }
+
+func TestSkillMenuToggle(t *testing.T) {
+	g := NewGame()
+	inp := &skillInput{toggle: true}
+	g.input = inp
+	g.lastUpdate = time.Now()
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if !g.skillMenuOpen {
+		t.Fatalf("expected skill menu open")
+	}
+	inp.toggle = true
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if g.skillMenuOpen {
+		t.Fatalf("expected skill menu closed")
+	}
+}
+
+func TestSkillMenuNavigation(t *testing.T) {
+	g := NewGame()
+	inp := &skillInput{toggle: true}
+	g.input = inp
+	g.lastUpdate = time.Now()
+	g.Update() // open menu
+	inp.down = true
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if g.skillCursor == 0 {
+		t.Fatalf("expected cursor to move down")
+	}
+	inp.right = true
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if g.skillCategory != SkillDefense {
+		t.Fatalf("expected category to advance")
+	}
+}

--- a/v1/internal/game/skill_tree.go
+++ b/v1/internal/game/skill_tree.go
@@ -13,6 +13,24 @@ const (
 	SkillUtility
 )
 
+// String returns a human readable label for the category.
+func (c SkillCategory) String() string {
+	switch c {
+	case SkillOffense:
+		return "Offense"
+	case SkillDefense:
+		return "Defense"
+	case SkillTyping:
+		return "Typing"
+	case SkillAutomation:
+		return "Automation"
+	case SkillUtility:
+		return "Utility"
+	default:
+		return "Unknown"
+	}
+}
+
 // SkillNode represents a single unlockable skill in the global skill tree.
 type SkillNode struct {
 	ID       string
@@ -27,6 +45,18 @@ type SkillNode struct {
 type SkillTree struct {
 	Nodes map[string]*SkillNode
 	order []string
+}
+
+// NodesByCategory returns a slice of skill nodes belonging to the given category.
+func (t *SkillTree) NodesByCategory(cat SkillCategory) []*SkillNode {
+	var out []*SkillNode
+	for _, id := range t.order {
+		n := t.Nodes[id]
+		if n.Category == cat {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // GetPrerequisites returns the prerequisite IDs for a given node.

--- a/v1/internal/game/skill_tree_overlay_test.go
+++ b/v1/internal/game/skill_tree_overlay_test.go
@@ -1,0 +1,18 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+type stubInputSkill struct{ stubInputOverlay }
+
+func TestDrawSkillTreeOverlay(t *testing.T) {
+	g := NewGame()
+	g.input = &stubInputSkill{}
+	g.skillMenuOpen = true
+	hud := NewHUD(g)
+	img := ebiten.NewImage(1920, 1080)
+	hud.drawSkillTreeOverlay(img)
+}


### PR DESCRIPTION
## Summary
- enable Tab to toggle a skill tree overlay
- track skill categories and selection in `Game`
- draw the skill tree overlay in the HUD
- expose skill helpers in `SkillTree`
- update docs and roadmap
- add unit tests for menu toggle and navigation

## Testing
- `go vet -tags=headless ./...` *(fails: X11/ALSA missing)*
- `go test -tags=headless ./...` *(fails: ALSA missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841d182c6d08327a0a21e30cf0da934