### PR TITLE
Implement skill unlock logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ for three minutes and verifies that all resources accumulate from zero.
 - Letter unlock order and costs documented (see `docs/LETTER_UNLOCKS.md`).
  - Letters can now be unlocked in-game using King's Points, expanding each building's word pool.
  - Tech trees are defined in YAML under `data/trees/` (see `letters_basic.yaml`). They are loaded at runtime via a Go parser that builds an in-memory graph and verifies all prerequisites.
+ - Skill tree nodes can be purchased with King's Points once prerequisites are met.
 
 ## Tech Tree YAML
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -111,6 +111,7 @@ All new features are optional enhancements, preserving the educational and acces
 - **SKILL-1** The global skill tree organizes nodes into Offense, Defense, Typing, Automation, and Utility categories.
 - **SKILL-2** Go structs `SkillCategory`, `SkillNode`, and `SkillTree` define the skill tree in memory.
 - **SKILL-3** `SampleSkillTree` provides a validated in-memory tree with example nodes for each category.
+- **SKILL-4** Skills can be unlocked by spending King's Points once prerequisites are met.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,7 +74,7 @@
   - [x] **SKILL-001.2** Implement in-memory skill tree structure and sample data
   - [ ] **SKILL-001.3** Add keyboard UI: open skill tree menu, navigate categories/nodes, show node details
   - [ ] **SKILL-001.4** Render skill tree overlay: display branches, highlight selected node, show unlock status
-  - [ ] **SKILL-001.5** Implement skill unlock logic: check prerequisites/resources, update state on unlock
+  - [x] **SKILL-001.5** Implement skill unlock logic: check prerequisites/resources, update state on unlock
   - [ ] **SKILL-001.6** Integrate skill effects with game systems (e.g., global stat boosts, automation unlocks)
   - [ ] **SKILL-001.7** Write unit tests for skill tree navigation, unlocks, and effect application
   - [ ] **SKILL-001.8** Persist skill tree state in save/load system

--- a/v1/internal/game/skill_tree_test.go
+++ b/v1/internal/game/skill_tree_test.go
@@ -44,3 +44,38 @@ func TestSkillTreeCycleDetect(t *testing.T) {
 		t.Fatalf("expected cycle error")
 	}
 }
+
+func TestSkillUnlockFlow(t *testing.T) {
+	tree, err := SampleSkillTree()
+	if err != nil {
+		t.Fatalf("sample tree: %v", err)
+	}
+	pool := &ResourcePool{}
+	pool.AddKingsPoints(50)
+
+	// cannot unlock rapid_fire before sharp_arrows
+	if tree.Unlock("rapid_fire", pool) {
+		t.Fatalf("rapid_fire unlocked without prereq")
+	}
+
+	if !tree.Unlock("sharp_arrows", pool) {
+		t.Fatalf("failed to unlock sharp_arrows")
+	}
+	if !tree.unlocked["sharp_arrows"] {
+		t.Fatalf("sharp_arrows not marked unlocked")
+	}
+
+	if pool.KingsAmount() != 40 {
+		t.Fatalf("expected 40 KP remaining got %d", pool.KingsAmount())
+	}
+
+	if !tree.Unlock("rapid_fire", pool) {
+		t.Fatalf("failed to unlock rapid_fire after prereq")
+	}
+	if pool.KingsAmount() != 20 {
+		t.Fatalf("expected 20 KP remaining got %d", pool.KingsAmount())
+	}
+	if !tree.unlocked["rapid_fire"] {
+		t.Fatalf("rapid_fire not marked unlocked")
+	}
+}


### PR DESCRIPTION
## Summary
- add unlocked state and unlock functions to `SkillTree`
- initialize unlocked map in `SampleSkillTree`
- test unlocking flow with KP costs
- document skill unlocks in README and REQUIREMENTS
- mark roadmap item SKILL-001.5 complete

## Testing
- `go vet -tags=headless ./...` *(fails: Xrandr.h missing)*
- `go test -tags=headless ./...` *(fails: Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841d1a05168832790906fd6cad0271f