### PR TITLE
Implement skill tree effects and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ See the [ROADMAP.md](./ROADMAP.md) for detailed tasks.
 - Press `/` to enter tower selection mode. The screen dims and towers are labeled with letters; press a letter to open that tower's upgrade menu.
 - Press `/` again to open the tech menu. Type to search unlocked technologies and press `Enter` to purchase the highlighted upgrade.
 - Press `Tab` to open the global skill tree. Use arrow keys to change categories and highlight skills. Locked and unlocked skills are indicated.
+- Unlocking a skill immediately applies its bonuses and is saved with your game.
 - Press `:` to enter command mode for quick text commands like `pause` or `quit`.
 
 See docs/REQUIREMENTS.md for the full feature scaffold, ROADMAP.md for planned phases, and TODO.md for sprint tasks.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -113,6 +113,7 @@ All new features are optional enhancements, preserving the educational and acces
 - **SKILL-3** `SampleSkillTree` provides a validated in-memory tree with example nodes for each category.
 - **SKILL-4** Skills can be unlocked by spending King's Points once prerequisites are met.
 - **SKILL-5** `Tab` opens the skill tree menu. Arrow keys switch categories and navigate nodes, highlighting the current selection and showing locked/unlocked status.
+- **SKILL-6** Unlocking a skill applies its effects to the game (tower stats, base HP, etc.).
 
 ---
 
@@ -154,7 +155,8 @@ All new features are optional enhancements, preserving the educational and acces
 ## 8 Persistence
 
 - **SAVE-1** Auto-save every wave: letter unlock state, tech trees, resources.  
-- **SAVE-2** Three local save-slots; JSON format, versioned.  
+- **SAVE-2** Three local save-slots; JSON format, versioned.
+- **SAVE-3** Skill tree unlocks persist in save files and are restored on load.
 
 *Planned: Save skill tree, minion unlocks, idle progress, and minigame achievements.*
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,9 +75,9 @@
   - [x] **SKILL-001.3** Add keyboard UI: open skill tree menu, navigate categories/nodes, show node details
   - [x] **SKILL-001.4** Render skill tree overlay: display branches, highlight selected node, show unlock status
   - [x] **SKILL-001.5** Implement skill unlock logic: check prerequisites/resources, update state on unlock
-  - [ ] **SKILL-001.6** Integrate skill effects with game systems (e.g., global stat boosts, automation unlocks)
-  - [ ] **SKILL-001.7** Write unit tests for skill tree navigation, unlocks, and effect application
-  - [ ] **SKILL-001.8** Persist skill tree state in save/load system
+  - [x] **SKILL-001.6** Integrate skill effects with game systems (e.g., global stat boosts, automation unlocks)
+  - [x] **SKILL-001.7** Write unit tests for skill tree navigation, unlocks, and effect application
+  - [x] **SKILL-001.8** Persist skill tree state in save/load system
 
 ---
 

--- a/v1/internal/game/skill_menu_test.go
+++ b/v1/internal/game/skill_menu_test.go
@@ -76,3 +76,27 @@ func TestSkillMenuNavigation(t *testing.T) {
 		t.Fatalf("expected category to advance")
 	}
 }
+
+func TestSkillUnlockAppliesEffect(t *testing.T) {
+	g := NewGame()
+	g.resources.AddKingsPoints(50)
+	inp := &skillInput{toggle: true}
+	g.input = inp
+	g.lastUpdate = time.Now()
+	g.Update()      // open menu
+	inp.down = true // select sharp_arrows
+	g.Update()
+	inp.enter = true
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if !g.unlockedSkills["sharp_arrows"] {
+		t.Fatalf("skill not unlocked")
+	}
+	if g.resources.KingsAmount() != 40 {
+		t.Fatalf("Kings Points not deducted")
+	}
+	if g.towerMods.DamageMult <= 1.0 {
+		t.Fatalf("damage multiplier not applied")
+	}
+}

--- a/v1/internal/game/skill_persistence_test.go
+++ b/v1/internal/game/skill_persistence_test.go
@@ -1,0 +1,38 @@
+//go:build test
+
+package game
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSkillStatePersistence(t *testing.T) {
+	g := NewGame()
+	g.resources.AddKingsPoints(50)
+	node := g.skillTree.Nodes["sharp_arrows"]
+	if !g.skillTree.Unlock("sharp_arrows", &g.resources) {
+		t.Fatalf("unlock failed")
+	}
+	g.unlockedSkills["sharp_arrows"] = true
+	g.applySkillEffects(node)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "save.json")
+	g.saveGame(path)
+
+	ng := NewGame()
+	if err := ng.loadGame(path); err != nil {
+		t.Fatal(err)
+	}
+	if !ng.unlockedSkills["sharp_arrows"] {
+		t.Fatalf("skill not loaded")
+	}
+	if ng.towerMods.DamageMult != 1.1 {
+		t.Fatalf("modifier not restored")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("save file missing")
+	}
+}


### PR DESCRIPTION
## Summary
- integrate skill effects with towers and base
- save/load unlocked skills
- add tests for skill unlocking, effects and persistence
- document skill effect persistence in README and requirements
- mark SKILL-001.6, SKILL-001.7 and SKILL-001.8 complete

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841e921e0b48327978e5c03591cb96e