### PR TITLE
Implement STATE-001 game phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ for three minutes and verifies that all resources accumulate from zero.
 - Typing speed/accuracy multiplier working.
 - Vim navigation for pause/menu/shop implemented.
 - Title screen with animated background and keyboard-only menu.
+- Game states now managed via a `GamePhase` enum (MainMenu, PreGame, Playing, Paused, Settings, GameOver).
 - Pre-game setup lets you choose a character and difficulty, shows a quick
   tutorial and typing test, then prompts for mode selection.
 - Letter unlock order and costs documented (see `docs/LETTER_UNLOCKS.md`).

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -136,6 +136,7 @@ All new features are optional enhancements, preserving the educational and acces
 | **UI-TITLE-1** | Game starts at a title screen with Start, Settings and Quit options. |
 | **UI-TITLE-2** | Title screen has a simple animated background and is keyboard navigable. |
 | **UI-PREGAME-1** | Pre-game setup screen handles character and difficulty selection, tutorial, typing test and mode selection. |
+| **UI-STATE-1** | Game phases include MainMenu, PreGame, Playing, Paused, Settings and GameOver with keyboard navigation between them. |
 | **UI-TOWER-1** | `/` enters tower selection mode, labels towers with letters and opens an upgrade menu for the chosen tower. |
 | **UI-TOWER-2** | While selecting, the HUD overlays each tower with a yellow box and its letter label. |
 | **UI-TOWER-2** | Tower selection mode dims the background and displays letter labels above towers. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,13 +112,13 @@
 
 ## Game States & Persistence
 
-- [ ] **STATE-001** Proper game state management (MainMenu, PreGame, Playing, Paused, GameOver, Settings)
-  - [ ] **T-001** Define a `GamePhase` enum/type covering all major states (MainMenu, PreGame, Playing, Paused, GameOver, Settings)
-  - [ ] **T-002** Refactor main game loop to use `GamePhase` for state transitions
-  - [ ] **T-003** Implement state transition logic (e.g., menu → pregame → playing → paused/gameover/settings)
-  - [ ] **T-004** Ensure each state has a dedicated update and draw handler
-  - [ ] **T-005** Add keyboard navigation and transitions between states (e.g., Esc to pause, Enter to continue)
-  - [ ] **T-006** Write unit tests for state transitions and edge cases
+- [x] **STATE-001** Proper game state management (MainMenu, PreGame, Playing, Paused, GameOver, Settings)
+  - [x] **T-001** Define a `GamePhase` enum/type covering all major states (MainMenu, PreGame, Playing, Paused, GameOver, Settings)
+  - [x] **T-002** Refactor main game loop to use `GamePhase` for state transitions
+  - [x] **T-003** Implement state transition logic (e.g., menu → pregame → playing → paused/gameover/settings)
+  - [x] **T-004** Ensure each state has a dedicated update and draw handler
+  - [x] **T-005** Add keyboard navigation and transitions between states (e.g., Esc to pause, Enter to continue)
+  - [x] **T-006** Write unit tests for state transitions and edge cases
 
 - [ ] **SAVE-001** Comprehensive save/load system (multiple slots, auto-save)
   - [ ] **T-001** Design a save file structure supporting multiple slots and versioning

--- a/v1/internal/game/command_mode_test.go
+++ b/v1/internal/game/command_mode_test.go
@@ -49,7 +49,7 @@ func TestEnterCommandMode(t *testing.T) {
 	if err := g.Update(); err != nil {
 		t.Fatal(err)
 	}
-	if !g.paused {
+	if g.phase != PhasePaused {
 		t.Fatalf("expected command executed")
 	}
 	if g.commandMode {

--- a/v1/internal/game/mainmenu_test.go
+++ b/v1/internal/game/mainmenu_test.go
@@ -34,7 +34,7 @@ func (m *menuInput) SkillMenu() bool    { return false }
 
 func TestMainMenuStartGame(t *testing.T) {
 	g := NewGame()
-	g.phase = PhaseMenu
+	g.phase = PhaseMainMenu
 	g.mainMenu = NewMainMenu()
 	inp := &menuInput{enter: true}
 	g.input = inp
@@ -49,7 +49,7 @@ func TestMainMenuStartGame(t *testing.T) {
 
 func TestMainMenuCursorWrap(t *testing.T) {
 	g := NewGame()
-	g.phase = PhaseMenu
+	g.phase = PhaseMainMenu
 	g.mainMenu = NewMainMenu()
 	inp := &menuInput{up: true}
 	g.input = inp
@@ -64,7 +64,7 @@ func TestMainMenuCursorWrap(t *testing.T) {
 
 func TestMainMenuSettingsToggle(t *testing.T) {
 	g := NewGame()
-	g.phase = PhaseMenu
+	g.phase = PhaseMainMenu
 	g.mainMenu = NewMainMenu()
 	g.mainMenu.cursor = 1
 	inp := &menuInput{enter: true}

--- a/v1/internal/game/state.go
+++ b/v1/internal/game/state.go
@@ -4,7 +4,28 @@ package game
 type GamePhase int
 
 const (
-	PhaseMenu GamePhase = iota
+	PhaseMainMenu GamePhase = iota
 	PhasePreGame
 	PhasePlaying
+	PhasePaused
+	PhaseGameOver
+	PhaseSettings
 )
+
+func (p GamePhase) String() string {
+	switch p {
+	case PhaseMainMenu:
+		return "MainMenu"
+	case PhasePreGame:
+		return "PreGame"
+	case PhasePlaying:
+		return "Playing"
+	case PhasePaused:
+		return "Paused"
+	case PhaseGameOver:
+		return "GameOver"
+	case PhaseSettings:
+		return "Settings"
+	}
+	return "Unknown"
+}

--- a/v1/internal/game/state_transition_test.go
+++ b/v1/internal/game/state_transition_test.go
@@ -1,0 +1,53 @@
+package game
+
+import (
+	"testing"
+	"time"
+)
+
+type pauseInput struct {
+	space bool
+	enter bool
+}
+
+func (p *pauseInput) TypedChars() []rune { return nil }
+func (p *pauseInput) Update()            {}
+func (p *pauseInput) Reset()             { p.space, p.enter = false, false }
+func (p *pauseInput) Backspace() bool    { return false }
+func (p *pauseInput) Space() bool        { v := p.space; p.space = false; return v }
+func (p *pauseInput) Quit() bool         { return false }
+func (p *pauseInput) Reload() bool       { return false }
+func (p *pauseInput) Enter() bool        { v := p.enter; p.enter = false; return v }
+func (p *pauseInput) Left() bool         { return false }
+func (p *pauseInput) Right() bool        { return false }
+func (p *pauseInput) Up() bool           { return false }
+func (p *pauseInput) Down() bool         { return false }
+func (p *pauseInput) Build() bool        { return false }
+func (p *pauseInput) Save() bool         { return false }
+func (p *pauseInput) Load() bool         { return false }
+func (p *pauseInput) SelectTower() bool  { return false }
+func (p *pauseInput) Command() bool      { return false }
+func (p *pauseInput) TechMenu() bool     { return false }
+func (p *pauseInput) SkillMenu() bool    { return false }
+
+func TestPauseResumeTransition(t *testing.T) {
+	g := NewGame()
+	g.phase = PhasePlaying
+	inp := &pauseInput{space: true}
+	g.input = inp
+	g.lastUpdate = time.Now()
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if g.phase != PhasePaused {
+		t.Fatalf("expected PhasePaused got %v", g.phase)
+	}
+	g.pauseCursor = 0
+	inp.enter = true
+	if err := g.Update(); err != nil {
+		t.Fatal(err)
+	}
+	if g.phase != PhasePlaying {
+		t.Fatalf("expected PhasePlaying got %v", g.phase)
+	}
+}


### PR DESCRIPTION
## Summary
- add new `GamePhase` enumeration for major states
- refactor game loop and input handling to use `GamePhase`
- implement `updatePaused` and `updateSettings` handlers
- update draw logic for paused, settings and game over screens
- add pause/resume state transition tests
- document game phase system in README
- mark STATE-001 tasks complete in ROADMAP
- note new requirement for defined game phases

## Testing
- `go test -tags test ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_6841f56c56008327813691be08d809af