### PR TITLE
Add save slots and auto-save system

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ See the [ROADMAP.md](./ROADMAP.md) for detailed tasks.
 - Press `Tab` to open the global skill tree. Use arrow keys to change categories and highlight skills. Locked and unlocked skills are indicated.
 - Unlocking a skill immediately applies its bonuses and is saved with your game.
 - Press `:` to enter command mode for quick text commands like `pause` or `quit`.
+- Press `F2` or `F3` to open the save/load slot menu. Select a slot with the arrow keys and confirm with `Enter`.
+- The game auto-saves to the active slot whenever a wave ends.
 
 See docs/REQUIREMENTS.md for the full feature scaffold, ROADMAP.md for planned phases, and TODO.md for sprint tasks.
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -162,7 +162,9 @@ All new features are optional enhancements, preserving the educational and acces
 - **SAVE-1** Auto-save every wave: letter unlock state, tech trees, resources.  
 - **SAVE-2** Three local save-slots; JSON format, versioned.
 - **SAVE-3** Skill tree unlocks persist in save files and are restored on load.
-- **SAVE-4** [In Progress] Save file structure must support multiple slots and versioning for future compatibility.
+- **SAVE-4** Save file structure supports multiple slots and versioning for future compatibility.
+- **SAVE-5** Save/load menu lets the player choose one of three slots.
+- **SAVE-6** Version mismatches are detected and reported gracefully.
 
 *Planned: Save skill tree, minion unlocks, idle progress, and minigame achievements.*
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,13 +120,13 @@
   - [x] **T-005** Add keyboard navigation and transitions between states (e.g., Esc to pause, Enter to continue)
   - [x] **T-006** Write unit tests for state transitions and edge cases
 
-- [ ] **SAVE-001** Comprehensive save/load system (multiple slots, auto-save)
-  - [ ] **T-001** Design a save file structure supporting multiple slots and versioning
+- [x] **SAVE-001** Comprehensive save/load system (multiple slots, auto-save)
+  - [x] **T-001** Design a save file structure supporting multiple slots and versioning
   - [x] **T-002** Implement save/load logic for all core game data (resources, towers, buildings, tech, settings)
-  - [ ] **T-003** Add auto-save functionality (e.g., after each wave or major event)
-  - [ ] **T-004** Create a save/load menu UI for selecting slots
-  - [ ] **T-005** Handle save/load errors and version mismatches gracefully
-  - [ ] **T-006** Write integration tests for save/load, including slot switching and auto-save
+  - [x] **T-003** Add auto-save functionality (e.g., after each wave or major event)
+  - [x] **T-004** Create a save/load menu UI for selecting slots
+  - [x] **T-005** Handle save/load errors and version mismatches gracefully
+  - [x] **T-006** Write integration tests for save/load, including slot switching and auto-save
 
 ---
 

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -217,6 +217,26 @@ func (h *HUD) drawSkillMenu(screen *ebiten.Image) {
 	drawMenu(screen, lines, 760, 300)
 }
 
+// drawSlotMenu renders the save/load slot selection overlay when active.
+func (h *HUD) drawSlotMenu(screen *ebiten.Image) {
+	if !h.game.slotMenuOpen {
+		return
+	}
+	title := "-- SAVE SLOT --"
+	if !h.game.slotModeSave {
+		title = "-- LOAD SLOT --"
+	}
+	lines := []string{title}
+	for i := 0; i < 3; i++ {
+		prefix := "  "
+		if i == h.game.slotCursor {
+			prefix = "> "
+		}
+		lines = append(lines, fmt.Sprintf("%sSlot %d", prefix, i+1))
+	}
+	drawMenu(screen, lines, 860, 480)
+}
+
 // drawSkillTreeOverlay renders the global skill tree when active.
 func (h *HUD) drawSkillTreeOverlay(screen *ebiten.Image) {
 	if !h.game.skillMenuOpen {
@@ -269,4 +289,5 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 	h.drawTowerSelectionOverlay(screen)
 	h.drawTechMenu(screen)
 	h.drawSkillMenu(screen)
+	h.drawSlotMenu(screen)
 }

--- a/v1/internal/game/save_system_test.go
+++ b/v1/internal/game/save_system_test.go
@@ -1,0 +1,62 @@
+//go:build test
+
+package game
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSaveVersionMismatch ensures loading a file with the wrong version fails.
+func TestSaveVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "slot1.json")
+	sg := savedGame{Version: SaveVersion + 1}
+	b, _ := json.Marshal(sg)
+	os.WriteFile(path, b, 0644)
+
+	g := NewGame()
+	g.saveDir = dir
+	if err := g.loadGame(path); err == nil {
+		t.Fatalf("expected version error")
+	}
+}
+
+// TestAutoSaveCreatesFile verifies a save file is created after a wave.
+func TestAutoSaveCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	g := NewGame()
+	g.saveDir = dir
+	inp := &stubInput{}
+	g.input = inp
+
+	// simulate until first wave completes
+	for i := 0; i < 600; i++ {
+		if w, ok := g.Queue().Peek(); ok {
+			inp.typed = []rune(w.Text)
+		}
+		if err := g.Step(0.1); err != nil {
+			t.Fatal(err)
+		}
+		if g.shopOpen {
+			break
+		}
+	}
+	path := filepath.Join(dir, "save_slot1.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected save file: %v", err)
+	}
+}
+
+// TestSetSaveSlotChangesPath ensures SetSaveSlot picks the correct slot file.
+func TestSetSaveSlotChangesPath(t *testing.T) {
+	g := NewGame()
+	g.saveDir = "/tmp"
+	g.SetSaveSlot(2)
+	expect := filepath.Join("/tmp", "save_slot2.json")
+	if g.currentSavePath() != expect {
+		t.Fatalf("unexpected path %s", g.currentSavePath())
+	}
+}


### PR DESCRIPTION
## Summary
- design versioned save format
- add auto-save after each wave
- implement slot selection menu
- handle version mismatch errors on load
- document new persistence features
- update roadmap and requirements
- add tests for save system

## Testing
- `go test ./...` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841fbfff06c8327869843d33397ae92