### PR TITLE
Implement per-word typing metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See the [ROADMAP.md](./ROADMAP.md) for the up-to-date backlog and [TODO_ARCHIVE.
 - Barracks spawns Footmen when words are completed; combat is resolved against orc grunts.
 - Shared FIFO queue manager processes words letter-by-letter, with jam/back-pressure mechanics.
 - HUD displays queue, cooldowns, resources, and tower selection overlays.
+- The HUD also shows the last word's accuracy and completion time.
 - Title screen, pre-game setup, and save/load systems are in place.
 - Tech trees and skill trees are loaded from YAML and can be navigated and unlocked via keyboard.
 - See `docs/REQUIREMENTS.md` for the full feature scaffold.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -29,6 +29,7 @@ All new features are optional enhancements, preserving the educational and acces
 | **Q-QUEUE-3** | If ≥ 5 words backlog → base takes chip damage each second (prevent AFK). |
 | **Q-QUEUE-4** | Queue is rendered top center with colour coding by building family and word length caps (Basic 2-3, Power 4-6, Epic 6-8). |
 | **Q-QUEUE-5** | Queue items are processed letter-by-letter; words remain in the queue until all letters are typed correctly. |
+| **Q-QUEUE-6** | Per-word accuracy and completion time are recorded and stored in a history log. |
 
 ### 1.1 Letter Pools
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,12 +85,12 @@
 
 ## Typing Metrics & Minigames
 
-- [ ] **MET-001** Capture per-word accuracy & time
-  - [ ] Define data structures to store per-word accuracy and completion time
-  - [ ] Update queue processing logic to record accuracy and time for each word
-  - [ ] Store per-word stats in a history buffer or log
-  - [ ] Add unit tests to verify per-word stats are captured correctly
-  - [ ] Expose per-word stats to HUD or stats panel
+- [x] **MET-001** Capture per-word accuracy & time
+  - [x] Define data structures to store per-word accuracy and completion time
+  - [x] Update queue processing logic to record accuracy and time for each word
+  - [x] Store per-word stats in a history buffer or log
+  - [x] Add unit tests to verify per-word stats are captured correctly
+  - [x] Expose per-word stats to HUD or stats panel
 
 - [ ] **MET-002** Rolling WPM (last 30 s)
   - [ ] Implement a time-based buffer to track recent typing events

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -237,6 +237,25 @@ func (h *HUD) drawSlotMenu(screen *ebiten.Image) {
 	drawMenu(screen, lines, 860, 480)
 }
 
+// drawWordStats displays the last completed word's accuracy and time.
+func (h *HUD) drawWordStats(screen *ebiten.Image) {
+	hist := h.game.WordHistory()
+	if len(hist) == 0 {
+		return
+	}
+	stat := hist[len(hist)-1]
+	acc := 1.0
+	total := stat.Correct + stat.Incorrect
+	if total > 0 {
+		acc = float64(stat.Correct) / float64(total)
+	}
+	line := fmt.Sprintf("%s %.0f%% %.1fs", stat.Text, acc*100, stat.Duration.Seconds())
+	opts := &text.DrawOptions{}
+	opts.GeoM.Translate(10, 80)
+	opts.ColorScale.ScaleWithColor(color.White)
+	text.Draw(screen, line, BoldFont, opts)
+}
+
 // drawSkillTreeOverlay renders the global skill tree when active.
 func (h *HUD) drawSkillTreeOverlay(screen *ebiten.Image) {
 	if !h.game.skillMenuOpen {
@@ -285,6 +304,7 @@ func drawMenu(screen *ebiten.Image, lines []string, x, y int) {
 // Draw renders the HUD elements on screen
 func (h *HUD) Draw(screen *ebiten.Image) {
 	h.drawResourceIcons(screen)
+	h.drawWordStats(screen)
 	h.drawQueue(screen)
 	h.drawTowerSelectionOverlay(screen)
 	h.drawTechMenu(screen)

--- a/v1/internal/game/word_stats.go
+++ b/v1/internal/game/word_stats.go
@@ -1,0 +1,26 @@
+package game
+
+import "time"
+
+// WordStat captures accuracy and completion time for a single word.
+type WordStat struct {
+	Text      string        // word text
+	Correct   int           // correct letters typed
+	Incorrect int           // incorrect letters typed
+	Duration  time.Duration // time from first letter to completion
+	start     time.Time     // internal start time
+}
+
+// Start begins timing for the word if not already started.
+func (ws *WordStat) Start() {
+	if ws.start.IsZero() {
+		ws.start = time.Now()
+	}
+}
+
+// Finish marks the word as completed and records its duration.
+func (ws *WordStat) Finish() {
+	if !ws.start.IsZero() {
+		ws.Duration = time.Since(ws.start)
+	}
+}

--- a/v1/internal/game/word_stats_test.go
+++ b/v1/internal/game/word_stats_test.go
@@ -1,0 +1,37 @@
+package game
+
+import "testing"
+
+func TestWordStatsRecording(t *testing.T) {
+	g := NewGame()
+	g.phase = PhasePlaying
+	s := &stubInput{}
+	g.input = s
+
+	g.queue.Enqueue(Word{Text: "ab", Source: "Farmer"})
+
+	s.typed = []rune{'a'}
+	g.Update()
+	s.typed = []rune{'x'}
+	g.Update()
+	if !g.queueJam {
+		t.Fatalf("expected jam on wrong letter")
+	}
+	s.backspace = true
+	g.Update()
+	s.typed = []rune{'a'}
+	g.Update()
+	s.typed = []rune{'b'}
+	g.Update()
+
+	if len(g.wordHistory) != 1 {
+		t.Fatalf("expected 1 word stat got %d", len(g.wordHistory))
+	}
+	ws := g.wordHistory[0]
+	if ws.Text != "ab" || ws.Correct != 3 || ws.Incorrect != 1 {
+		t.Fatalf("unexpected word stat %+v", ws)
+	}
+	if ws.Duration <= 0 {
+		t.Errorf("expected duration recorded")
+	}
+}


### PR DESCRIPTION
## Summary
- add `WordStat` for per-word accuracy and time
- track current word stats and history in the game loop
- show last word accuracy/time on HUD
- test word stat logging
- document new feature and requirement

## Testing
- `go test ./...` *(fails: module download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6842025779e48327b38ec98cd34d3daf