### PR TITLE
Implement rolling WPM metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See the [ROADMAP.md](./ROADMAP.md) for the up-to-date backlog and [TODO_ARCHIVE.
 - Shared FIFO queue manager processes words letter-by-letter, with jam/back-pressure mechanics.
 - HUD displays queue, cooldowns, resources, and tower selection overlays.
 - The HUD also shows the last word's accuracy and completion time.
+- Rolling WPM for the last 30 seconds is displayed beneath word stats.
 - Title screen, pre-game setup, and save/load systems are in place.
 - Tech trees and skill trees are loaded from YAML and can be navigated and unlocked via keyboard.
 - See `docs/REQUIREMENTS.md` for the full feature scaffold.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -30,6 +30,7 @@ All new features are optional enhancements, preserving the educational and acces
 | **Q-QUEUE-4** | Queue is rendered top center with colour coding by building family and word length caps (Basic 2-3, Power 4-6, Epic 6-8). |
 | **Q-QUEUE-5** | Queue items are processed letter-by-letter; words remain in the queue until all letters are typed correctly. |
 | **Q-QUEUE-6** | Per-word accuracy and completion time are recorded and stored in a history log. |
+| **MET-1** | TypingStats computes rolling WPM using events from the last 30 seconds. |
 
 ### 1.1 Letter Pools
 
@@ -136,6 +137,7 @@ All new features are optional enhancements, preserving the educational and acces
 | **UI-RES-1** | HUD shows resource icons for Gold, Wood, Stone, Iron and Mana. |
 | **UI-QUEUE-1** | HUD displays the word queue with a conveyor belt animation. |
 | **UI-QUEUE-2** | The first queued word shows typed letters in gray to indicate progress. |
+| **UI-MET-1** | HUD displays rolling WPM calculated from the last 30 seconds. |
 | **UI-TITLE-1** | Game starts at a title screen with Start, Settings and Quit options. |
 | **UI-TITLE-2** | Title screen has a simple animated background and is keyboard navigable. |
 | **UI-PREGAME-1** | Pre-game setup screen handles character and difficulty selection, tutorial, typing test and mode selection. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,12 +86,12 @@
   - [x] Add unit tests to verify per-word stats are captured correctly
   - [x] Expose per-word stats to HUD or stats panel
 
-- [ ] **MET-002** Rolling WPM (last 30 s)
-  - [ ] Implement a time-based buffer to track recent typing events
-  - [ ] Calculate rolling WPM using only events from the last 30 seconds
-  - [ ] Add method to TypingStats or a new struct for rolling WPM
-  - [ ] Write tests to verify rolling WPM calculation
-  - [ ] Display rolling WPM in the HUD or stats panel
+- [x] **MET-002** Rolling WPM (last 30 s)
+  - [x] Implement a time-based buffer to track recent typing events
+  - [x] Calculate rolling WPM using only events from the last 30 seconds
+  - [x] Add method to TypingStats or a new struct for rolling WPM
+  - [x] Write tests to verify rolling WPM calculation
+  - [x] Display rolling WPM in the HUD or stats panel
 
 - [ ] **UI-MET** Toggle stats panel (`Tab`)
   - [ ] Add a boolean field to Game for stats panel visibility

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -254,6 +254,12 @@ func (h *HUD) drawWordStats(screen *ebiten.Image) {
 	opts.GeoM.Translate(10, 80)
 	opts.ColorScale.ScaleWithColor(color.White)
 	text.Draw(screen, line, BoldFont, opts)
+
+	wpmLine := fmt.Sprintf("WPM: %.1f", h.game.typing.RollingWPM())
+	opts = &text.DrawOptions{}
+	opts.GeoM.Translate(10, 100)
+	opts.ColorScale.ScaleWithColor(color.White)
+	text.Draw(screen, wpmLine, BoldFont, opts)
 }
 
 // drawSkillTreeOverlay renders the global skill tree when active.

--- a/v1/internal/game/typing_stats_test.go
+++ b/v1/internal/game/typing_stats_test.go
@@ -56,3 +56,22 @@ func TestScoreMultiplierAndHistory(t *testing.T) {
 		t.Errorf("history not updated")
 	}
 }
+
+func TestRollingWPM(t *testing.T) {
+	ts := NewTypingStats()
+	base := time.Now()
+	ts.now = func() time.Time { return base }
+	for i := 0; i < 25; i++ {
+		ts.events = append(ts.events, base.Add(-time.Duration(i)*time.Second))
+	}
+	wpm := ts.RollingWPM()
+	if wpm < 9.9 || wpm > 10.1 {
+		t.Errorf("expected ~10 WPM got %.2f", wpm)
+	}
+
+	ts.events = append(ts.events, base.Add(-40*time.Second))
+	wpm = ts.RollingWPM()
+	if wpm < 9.9 || wpm > 10.1 {
+		t.Errorf("old events should be ignored got %.2f", wpm)
+	}
+}


### PR DESCRIPTION
## Summary
- compute rolling WPM from last 30 seconds of typing
- show rolling WPM in HUD under word stats
- document feature and requirements
- mark MET-002 complete on the roadmap

## Testing
- `go vet ./...` *(fails: Get ... Forbidden)*
- `go test ./...` *(fails: Get ... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68420481d0d08327973263a5864f3414