### PR TITLE
Implement FUZZ-001 engine fuzz tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ go test -tags test ./...
 The `resources_integration_test.go` integration test runs the game headlessly
 for three minutes and verifies that all resources accumulate from zero.
 
+Fuzz testing can be executed with Go 1.23+:
+
+```bash
+go test -run Fuzz -fuzz FuzzGameRandomInput ./...
+```
+
+The fuzz harness reports the game's internal state and a full stack trace on
+any panic so unexpected crashes are easy to diagnose.
+
 -## Current prototype
 
 - Shared FIFO queue manager implemented. Buildings enqueue words that are processed **letter by letter**. Completing a Barracks word spawns a Footman.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -181,6 +181,7 @@ All new features are optional enhancements, preserving the educational and acces
 - **TEST-1** Unit tests cover queue manager, letter generator, tech unlock gating, damage math, Vim navigation.  
 - **TEST-2** Integration tests simulate 100 waves at 40 WPM 95 % accuracy – must not crash; TTK < Tsurvive.
 - **TEST-3** A headless `Step` function (build tag `test`) allows end-to-end simulation of the core gameplay loop.
+- **FUZZ-1** Fuzz tests feed random input into the engine's Step function to ensure robustness against crashes.
 - **BENCH** Benchmark reload throughput vs 60 Hz update loop (Ebiten frame).
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,7 +117,7 @@
 - [ ] **IDLE-001** Auto-collection and offline progress
 - [ ] **IDLE-002** Upgradable idle generators
 - [ ] **IDLE-003** Prestige/reset system
-- [ ] **FUZZ-001** Engine fuzz tester and robustness checks
+- [x] **FUZZ-001** Engine fuzz tester and robustness checks
 - [ ] **FUZZ-002** Stress test for performance and stability
 - [ ] **FUZZ-003** Automated regression tests for core systems
 

--- a/v1/internal/game/fuzz_engine_test.go
+++ b/v1/internal/game/fuzz_engine_test.go
@@ -1,0 +1,56 @@
+package game
+
+import (
+	"encoding/json"
+	"runtime/debug"
+	"testing"
+)
+
+// FuzzGameRandomInput runs the game step with random input bytes to ensure
+// robustness against unexpected sequences. It uses Go's built-in fuzzing
+// to feed arbitrary byte slices as typed characters or backspace events.
+func FuzzGameRandomInput(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		g := NewGame()
+		inp := &stubInput{}
+		g.input = inp
+
+		captureState := func() string {
+			s := struct {
+				Wave     int `json:"wave"`
+				BaseHP   int `json:"base_hp"`
+				QueueLen int `json:"queue_len"`
+				Mobs     int `json:"mobs"`
+				Towers   int `json:"towers"`
+			}{
+				Wave:     g.currentWave,
+				BaseHP:   g.base.Health(),
+				QueueLen: g.queue.Len(),
+				Mobs:     len(g.mobs),
+				Towers:   len(g.towers),
+			}
+			b, _ := json.MarshalIndent(s, "", "  ")
+			return string(b)
+		}
+
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("panic: %v\nstate: %s\ninput: %v\n%s", r, captureState(), data, debug.Stack())
+			}
+		}()
+
+		for i, b := range data {
+			if b%50 == 0 {
+				inp.backspace = true
+			} else {
+				inp.typed = []rune{rune('a' + b%26)}
+			}
+			if err := g.Step(0.05); err != nil {
+				t.Fatalf("step error: %v\nstate: %s\ninput index %d: %v", err, captureState(), i, data[:i+1])
+			}
+			if i > 1000 {
+				break // limit runtime for extreme inputs
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add fuzz test to feed random input to engine
- document fuzz testing instructions in README
- mark FUZZ-001 complete in ROADMAP
- note fuzz testing requirement in REQUIREMENTS
- capture full state and stack trace for fuzz failures

## Testing
- `./v1/pre-commit.sh` *(fails: could not download Go modules)*

------
https://chatgpt.com/codex/tasks/task_e_68420a3a29748327a5b021bfcdb128c1