### PR TITLE
Add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Game logic is organized into modules under `internal/` (`entity`, `ui`, `tech`,
 `Handler` with an `Update(dt)` method. Handlers communicate through a lightweight
 event bus, and `game.Game` coordinates rendering using the state from all
 handlers.
+For a deeper look at the pattern, see [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md).
 
 -## Current prototype
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,43 @@
+# Architecture Overview
+
+This document summarizes the modular handler pattern introduced in the `v1` directory. It serves as a reference for contributors who are exploring the codebase.
+
+## Module Layout
+
+All gameplay code lives under `v1/internal/`. Modules include:
+
+- `entity` – ally and enemy units
+- `ui` – HUD, menus and overlays
+- `tech` – tech tree and skill tree logic
+- `tower` – towers, projectiles and related logic
+- `phase` – game state transitions
+- `content` – asset loading helpers
+- `sprite` – image helpers and sprite utilities
+- `event` – event bus and event types
+
+Each module exposes a `Handler` with an `Update(dt float64)` method. The `Handler` interface allows the main game engine to update modules in a uniform manner.
+
+## Event Bus
+
+`internal/event` provides a lightweight pub/sub system. Each handler exposes channels for its specific event type (for example `EntityEvents` or `UIEvents`). Handlers subscribe to the events they care about using the shared `EventBus` and communicate by publishing events.
+
+Example:
+
+```go
+// Publishing a notification from the tech handler
+bus.Publish("ui", event.UIEvent{Type: "notification", Payload: "Tech unlocked"})
+
+// UI handler subscribes to UI events
+bus.Subscribe("ui", uiCh)
+```
+
+The `game.Game` struct owns a pointer to every handler and the shared `EventBus`. During `Game.Update` each handler's `Update` method is called. Rendering is also coordinated by `game.Game` using state from these handlers.
+
+## Adding New Features
+
+1. Create a new module under `internal/` if needed and define a `Handler`.
+2. Add event types or channels in `internal/event` if the new module needs to communicate with others.
+3. Wire the handler and its event channels into `game.Game` (see the existing fields for guidance).
+4. Keep event payloads small and decoupled. Prefer passing IDs or simple structs rather than large objects.
+
+This pattern keeps modules loosely coupled while still allowing coordination through events.


### PR DESCRIPTION
## Summary
- document handler/event architecture
- link to the architecture overview from the README

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842306430408327bedd8dc9b64343c7