### PR TITLE
Move units to entity module

### DIFF
--- a/v1/internal/entity/assets.go
+++ b/v1/internal/entity/assets.go
@@ -1,0 +1,8 @@
+package entity
+
+import "github.com/hajimehoshi/ebiten/v2"
+
+var (
+	ImgFootman *ebiten.Image
+	ImgMobA    *ebiten.Image
+)

--- a/v1/internal/entity/entity.go
+++ b/v1/internal/entity/entity.go
@@ -1,4 +1,4 @@
-package game
+package entity
 
 import (
 	"github.com/hajimehoshi/ebiten/v2"

--- a/v1/internal/entity/footman.go
+++ b/v1/internal/entity/footman.go
@@ -1,6 +1,8 @@
-package game
+package entity
 
-import "github.com/hajimehoshi/ebiten/v2"
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+)
 
 // Footman represents a simple melee unit spawned from the Barracks with basic
 // combat stats.

--- a/v1/internal/entity/orcgrunt.go
+++ b/v1/internal/entity/orcgrunt.go
@@ -1,6 +1,8 @@
-package game
+package entity
 
-import "github.com/hajimehoshi/ebiten/v2"
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+)
 
 // OrcGrunt represents a basic enemy foot soldier.
 type OrcGrunt struct {

--- a/v1/internal/entity/point.go
+++ b/v1/internal/entity/point.go
@@ -1,4 +1,4 @@
-package game
+package entity
 
 import "math"
 

--- a/v1/internal/game/barracks.go
+++ b/v1/internal/game/barracks.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 
 	"github.com/daddevv/type-defense/internal/econ"
+	"github.com/daddevv/type-defense/internal/entity"
 )
 
 // Barracks represents a Military building that trains Footman units.
@@ -67,11 +68,11 @@ func (b *Barracks) generateWord() string {
 }
 
 // OnWordCompleted spawns a Footman if the provided word matches the pending one.
-func (b *Barracks) OnWordCompleted(word string) *Footman {
+func (b *Barracks) OnWordCompleted(word string) *entity.Footman {
 	if word == b.pendingWord {
 		b.pendingWord = ""
 		b.timer.Reset()
-		unit := NewFootman(0, 0)
+		unit := entity.NewFootman(0, 0)
 		if b.military != nil {
 			b.military.AddUnit(unit)
 		}

--- a/v1/internal/game/base.go
+++ b/v1/internal/game/base.go
@@ -1,11 +1,13 @@
 package game
 
+import "github.com/daddevv/type-defense/internal/entity"
+
 // Base represents the player's base that mobs try to destroy.
 const BaseStartingHealth = 10
 
 // Base represents the player's base that mobs try to destroy.
 type Base struct {
-	BaseEntity
+	entity.BaseEntity
 	health int
 }
 
@@ -13,8 +15,8 @@ type Base struct {
 func NewBase(x, y float64, hp int) *Base {
 	w, h := ImgBase.Bounds().Dx(), ImgBase.Bounds().Dy()
 	return &Base{
-		BaseEntity: BaseEntity{
-			pos:          Point{x, y},
+		BaseEntity: entity.BaseEntity{
+			pos:          entity.Point{x, y},
 			width:        w,
 			height:       h,
 			frame:        ImgBase,

--- a/v1/internal/game/combat_edge_test.go
+++ b/v1/internal/game/combat_edge_test.go
@@ -1,9 +1,12 @@
 package game
 
-import "testing"
+import (
+	"github.com/daddevv/type-defense/internal/entity"
+	"testing"
+)
 
 // helper to update orc slice and remove dead ones
-func updateOrcs(orcs []*OrcGrunt, dt float64) []*OrcGrunt {
+func updateOrcs(orcs []*entity.OrcGrunt, dt float64) []*entity.OrcGrunt {
 	for i := 0; i < len(orcs); {
 		o := orcs[i]
 		o.Update(dt)
@@ -17,14 +20,14 @@ func updateOrcs(orcs []*OrcGrunt, dt float64) []*OrcGrunt {
 }
 
 func TestFootmanSurvivesAfterKill(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 
 	m := NewMilitary()
 	m.AddUnit(f)
-	orcs := []*OrcGrunt{o}
+	orcs := []*entity.OrcGrunt{o}
 
 	for steps := 0; o.Alive() && steps < 10; steps++ {
 		orcs = updateOrcs(orcs, 0.1)
@@ -40,16 +43,16 @@ func TestFootmanSurvivesAfterKill(t *testing.T) {
 }
 
 func TestFootmanDiesLethalDamage(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
 	f.hp = 2
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 	o.damage = 5
 
 	m := NewMilitary()
 	m.AddUnit(f)
-	orcs := []*OrcGrunt{o}
+	orcs := []*entity.OrcGrunt{o}
 
 	orcs = updateOrcs(orcs, 0.1)
 	orcs = m.Update(0.1, orcs)
@@ -63,14 +66,14 @@ func TestCombatMultipleCombinations(t *testing.T) {
 	combos := []struct{ f, g int }{{1, 2}, {2, 1}, {2, 2}}
 	for _, c := range combos {
 		m := NewMilitary()
-		var orcs []*OrcGrunt
+		var orcs []*entity.OrcGrunt
 		for i := 0; i < c.f; i++ {
-			f := NewFootman(0, 0)
+			f := entity.NewFootman(0, 0)
 			f.speed = 0
 			m.AddUnit(f)
 		}
 		for i := 0; i < c.g; i++ {
-			o := NewOrcGrunt(0, 0)
+			o := entity.NewOrcGrunt(0, 0)
 			o.speed = 0
 			orcs = append(orcs, o)
 		}
@@ -97,18 +100,18 @@ func TestCombatMultipleCombinations(t *testing.T) {
 }
 
 func TestSimultaneousDamage(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
 	f.hp = 1
 	f.damage = 5
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 	o.hp = 5
 	o.damage = 1
 
 	m := NewMilitary()
 	m.AddUnit(f)
-	orcs := []*OrcGrunt{o}
+	orcs := []*entity.OrcGrunt{o}
 
 	orcs = updateOrcs(orcs, 0.1)
 	orcs = m.Update(0.1, orcs)
@@ -119,14 +122,14 @@ func TestSimultaneousDamage(t *testing.T) {
 }
 
 func TestNoCombatWithoutOverlap(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
-	o := NewOrcGrunt(1000, 0)
+	o := entity.NewOrcGrunt(1000, 0)
 	o.speed = 0
 
 	m := NewMilitary()
 	m.AddUnit(f)
-	orcs := []*OrcGrunt{o}
+	orcs := []*entity.OrcGrunt{o}
 
 	orcs = updateOrcs(orcs, 0.1)
 	hpF := f.Health()
@@ -139,14 +142,14 @@ func TestNoCombatWithoutOverlap(t *testing.T) {
 }
 
 func TestImmediateRemovalOfDeadUnits(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 
 	m := NewMilitary()
 	m.AddUnit(f)
-	orcs := []*OrcGrunt{o}
+	orcs := []*entity.OrcGrunt{o}
 
 	for steps := 0; steps < 10 && len(orcs) > 0; steps++ {
 		orcs = updateOrcs(orcs, 0.1)
@@ -163,15 +166,15 @@ func TestImmediateRemovalOfDeadUnits(t *testing.T) {
 }
 
 func TestDeadUnitsCannotAttack(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 	o.hp = 1
 
 	m := NewMilitary()
 	m.AddUnit(f)
-	orcs := []*OrcGrunt{o}
+	orcs := []*entity.OrcGrunt{o}
 
 	orcs = updateOrcs(orcs, 0.1)
 	orcs = m.Update(0.1, orcs)
@@ -187,15 +190,15 @@ func TestDeadUnitsCannotAttack(t *testing.T) {
 }
 
 func TestNoCombatWithDeadUnit(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
 	f.alive = false
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 
 	m := NewMilitary()
 	m.AddUnit(f)
-	orcs := []*OrcGrunt{o}
+	orcs := []*entity.OrcGrunt{o}
 
 	orcs = updateOrcs(orcs, 0.1)
 	hp := o.Health()
@@ -207,18 +210,18 @@ func TestNoCombatWithDeadUnit(t *testing.T) {
 }
 
 func TestBothUnitsDieSameTick(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
 	f.hp = 1
 	f.damage = 5
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 	o.hp = 5
 	o.damage = 5
 
 	m := NewMilitary()
 	m.AddUnit(f)
-	orcs := []*OrcGrunt{o}
+	orcs := []*entity.OrcGrunt{o}
 
 	orcs = updateOrcs(orcs, 0.1)
 	orcs = m.Update(0.1, orcs)
@@ -235,15 +238,15 @@ func TestRemovalDuringIterationNoPanic(t *testing.T) {
 		}
 	}()
 	m := NewMilitary()
-	var orcs []*OrcGrunt
+	var orcs []*entity.OrcGrunt
 	for i := 0; i < 3; i++ {
-		f := NewFootman(0, 0)
+		f := entity.NewFootman(0, 0)
 		f.speed = 0
 		f.hp = 1
 		m.AddUnit(f)
 	}
 	for i := 0; i < 3; i++ {
-		o := NewOrcGrunt(0, 0)
+		o := entity.NewOrcGrunt(0, 0)
 		o.speed = 0
 		o.damage = 5
 		orcs = append(orcs, o)

--- a/v1/internal/game/combat_integration_test.go
+++ b/v1/internal/game/combat_integration_test.go
@@ -2,15 +2,18 @@
 
 package game
 
-import "testing"
+import (
+	"github.com/daddevv/type-defense/internal/entity"
+	"testing"
+)
 
 // TestCombatKillTimeUnderEight simulates perfect typing resulting in a Footman
 // defeating an OrcGrunt. The battle should resolve in under eight seconds of
 // simulated time.
 func TestCombatKillTimeUnderEight(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 
 	m := NewMilitary()
@@ -20,7 +23,7 @@ func TestCombatKillTimeUnderEight(t *testing.T) {
 	elapsed := 0.0
 	for o.Alive() && elapsed < 10 {
 		o.Update(dt)
-		m.Update(dt, []*OrcGrunt{o})
+		m.Update(dt, []*entity.OrcGrunt{o})
 		elapsed += dt
 	}
 

--- a/v1/internal/game/content.go
+++ b/v1/internal/game/content.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/daddevv/type-defense/internal/entity"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 )
@@ -19,9 +20,9 @@ var (
 	ImgHouseTile            *ebiten.Image
 	ImgBase                 *ebiten.Image
 	ImgTower                *ebiten.Image
-	ImgMobA                 *ebiten.Image
+	ImgMobA                 *ebiten.Image // deprecated, use entity.ImgMobA
 	ImgMobB                 *ebiten.Image
-	ImgFootman              *ebiten.Image
+	ImgFootman              *ebiten.Image // deprecated, use entity.ImgFootman
 	ImgProjectile           *ebiten.Image
 )
 
@@ -33,8 +34,10 @@ func InitImages() {
 	ImgBase = generateBaseImage()
 	ImgTower = generateTowerImage()
 	ImgMobA = generateMobImage(color.RGBA{255, 0, 0, 255})
+	entity.ImgMobA = ImgMobA
 	ImgMobB = generateMobImage(color.RGBA{255, 128, 0, 255})
 	ImgFootman = generateMobImage(color.RGBA{0, 0, 255, 255})
+	entity.ImgFootman = ImgFootman
 	ImgProjectile = generateProjectileImage()
 	ImgBackgroundBasicTiles = generateBackground()
 }

--- a/v1/internal/game/entity_test.go
+++ b/v1/internal/game/entity_test.go
@@ -3,11 +3,12 @@ package game
 import (
 	"testing"
 
+	"github.com/daddevv/type-defense/internal/entity"
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
 func TestBaseEntityBounds(t *testing.T) {
-	e := &BaseEntity{pos: Point{X: 1, Y: 2}, width: 3, height: 4, frame: ebiten.NewImage(1, 1)}
+	e := &entity.BaseEntity{pos: entity.Point{X: 1, Y: 2}, width: 3, height: 4, frame: ebiten.NewImage(1, 1)}
 	x, y := e.Position()
 	if x != 1 || y != 2 {
 		t.Errorf("position expected (1,2) got (%v,%v)", x, y)

--- a/v1/internal/game/footman_test.go
+++ b/v1/internal/game/footman_test.go
@@ -1,9 +1,12 @@
 package game
 
-import "testing"
+import (
+	"github.com/daddevv/type-defense/internal/entity"
+	"testing"
+)
 
 func TestFootmanMovement(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 10
 	f.Update(1.0)
 	x, _ := f.Position()
@@ -13,7 +16,7 @@ func TestFootmanMovement(t *testing.T) {
 }
 
 func TestFootmanDefaults(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	if f.Health() != 10 {
 		t.Errorf("expected default HP 10 got %d", f.Health())
 	}
@@ -26,7 +29,7 @@ func TestFootmanDefaults(t *testing.T) {
 }
 
 func TestFootmanDamageKills(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.Damage(5)
 	if !f.Alive() {
 		t.Errorf("footman should still be alive")

--- a/v1/internal/game/military.go
+++ b/v1/internal/game/military.go
@@ -1,17 +1,19 @@
 package game
 
+import "github.com/daddevv/type-defense/internal/entity"
+
 // Military manages all player-controlled units such as Footmen.
 type Military struct {
-	units []*Footman
+	units []*entity.Footman
 }
 
 // NewMilitary creates an empty Military manager.
 func NewMilitary() *Military {
-	return &Military{units: make([]*Footman, 0)}
+	return &Military{units: make([]*entity.Footman, 0)}
 }
 
 // AddUnit registers a new Footman with the military system.
-func (m *Military) AddUnit(f *Footman) {
+func (m *Military) AddUnit(f *entity.Footman) {
 	if f != nil {
 		m.units = append(m.units, f)
 	}
@@ -24,7 +26,7 @@ func rectOverlap(ax, ay, aw, ah, bx, by, bw, bh int) bool {
 
 // Update advances all units, resolves combat with orc grunts, and removes any
 // that are no longer alive.
-func (m *Military) Update(dt float64, orcs []*OrcGrunt) []*OrcGrunt {
+func (m *Military) Update(dt float64, orcs []*entity.OrcGrunt) []*entity.OrcGrunt {
 	for i := 0; i < len(m.units); {
 		u := m.units[i]
 		u.Update(dt)
@@ -65,7 +67,7 @@ func (m *Military) Update(dt float64, orcs []*OrcGrunt) []*OrcGrunt {
 }
 
 // Units returns the list of active Footmen.
-func (m *Military) Units() []*Footman { return m.units }
+func (m *Military) Units() []*entity.Footman { return m.units }
 
 // Count returns the number of active units.
 func (m *Military) Count() int { return len(m.units) }

--- a/v1/internal/game/military_test.go
+++ b/v1/internal/game/military_test.go
@@ -1,13 +1,16 @@
 package game
 
-import "testing"
+import (
+	"github.com/daddevv/type-defense/internal/entity"
+	"testing"
+)
 
 func TestMilitaryAddAndCount(t *testing.T) {
 	m := NewMilitary()
 	if m.Count() != 0 {
 		t.Fatalf("expected empty military")
 	}
-	m.AddUnit(NewFootman(0, 0))
+	m.AddUnit(entity.NewFootman(0, 0))
 	if m.Count() != 1 {
 		t.Fatalf("expected 1 unit got %d", m.Count())
 	}

--- a/v1/internal/game/mob.go
+++ b/v1/internal/game/mob.go
@@ -1,10 +1,13 @@
 package game
 
-import "math"
+import (
+	"github.com/daddevv/type-defense/internal/entity"
+	"math"
+)
 
 // Mob represents a basic enemy moving left.
 type Mob struct {
-	BaseEntity
+	entity.BaseEntity
 	speed      float64
 	animTicker float64
 	alive      bool
@@ -24,8 +27,8 @@ type Mob struct {
 func NewMob(x, y float64, target *Base, hp int, speed float64) *Mob {
 	w, h := ImgMobA.Bounds().Dx(), ImgMobA.Bounds().Dy()
 	return &Mob{
-		BaseEntity: BaseEntity{
-			pos:          Point{x, y},
+		BaseEntity: entity.BaseEntity{
+			pos:          entity.Point{x, y},
 			width:        w,
 			height:       h,
 			frame:        ImgMobA,

--- a/v1/internal/game/orcgrunt_test.go
+++ b/v1/internal/game/orcgrunt_test.go
@@ -1,10 +1,13 @@
 package game
 
-import "testing"
+import (
+	"github.com/daddevv/type-defense/internal/entity"
+	"testing"
+)
 
 // TestOrcGruntDefaults verifies default stats.
 func TestOrcGruntDefaults(t *testing.T) {
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	if o.Health() != 5 {
 		t.Errorf("expected default HP 5 got %d", o.Health())
 	}
@@ -15,9 +18,9 @@ func TestOrcGruntDefaults(t *testing.T) {
 
 // TestCombatFootmanKillsGrunt ensures a footman defeats a grunt in melee.
 func TestCombatFootmanKillsGrunt(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 
 	m := NewMilitary()
@@ -25,7 +28,7 @@ func TestCombatFootmanKillsGrunt(t *testing.T) {
 
 	for i := 0; i < 6; i++ {
 		o.Update(0.1)
-		m.Update(0.1, []*OrcGrunt{o})
+		m.Update(0.1, []*entity.OrcGrunt{o})
 	}
 
 	if o.Alive() {
@@ -38,17 +41,17 @@ func TestCombatFootmanKillsGrunt(t *testing.T) {
 
 // TestCombatFootmanDies verifies footman removal when killed.
 func TestCombatFootmanDies(t *testing.T) {
-	f := NewFootman(0, 0)
+	f := entity.NewFootman(0, 0)
 	f.speed = 0
 	f.hp = 2
-	o := NewOrcGrunt(0, 0)
+	o := entity.NewOrcGrunt(0, 0)
 	o.speed = 0
 	o.damage = 5
 
 	m := NewMilitary()
 	m.AddUnit(f)
 
-	m.Update(0.1, []*OrcGrunt{o})
+	m.Update(0.1, []*entity.OrcGrunt{o})
 
 	if m.Count() != 0 {
 		t.Errorf("expected footman removed after death")

--- a/v1/internal/game/point_test.go
+++ b/v1/internal/game/point_test.go
@@ -1,17 +1,20 @@
 package game
 
-import "testing"
+import (
+	"github.com/daddevv/type-defense/internal/entity"
+	"testing"
+)
 
 func TestPointDistance(t *testing.T) {
-	p1 := NewPoint(0, 0)
-	p2 := NewPoint(3, 4)
+	p1 := entity.NewPoint(0, 0)
+	p2 := entity.NewPoint(3, 4)
 	if dist := p1.Distance(p2); dist != 5 {
 		t.Errorf("expected distance 5 got %v", dist)
 	}
 }
 
 func TestPointTranslate(t *testing.T) {
-	p := NewPoint(1, 2)
+	p := entity.NewPoint(1, 2)
 	p.Translate(3, 4)
 	if p.X != 4 || p.Y != 6 {
 		t.Errorf("expected (4,6) got (%v,%v)", p.X, p.Y)

--- a/v1/internal/game/projectile.go
+++ b/v1/internal/game/projectile.go
@@ -1,6 +1,9 @@
 package game
 
-import "math"
+import (
+	"github.com/daddevv/type-defense/internal/entity"
+	"math"
+)
 
 // calcIntercept returns a normalized direction vector from the shooter position
 // to where the projectile should aim in order to intercept the moving target.
@@ -44,7 +47,7 @@ func calcIntercept(px, py float64, target Enemy, speed float64) (float64, float6
 
 // Projectile represents a moving projectile toward a target.
 type Projectile struct {
-	BaseEntity
+	entity.BaseEntity
 	vx, vy float64
 	speed  float64
 	target Enemy
@@ -60,8 +63,8 @@ func NewProjectile(g *Game, x, y float64, target Enemy, dmg int, speed float64, 
 	vx, vy := calcIntercept(x, y, target, speed)
 	w, h := ImgProjectile.Bounds().Dx(), ImgProjectile.Bounds().Dy()
 	return &Projectile{
-		BaseEntity: BaseEntity{
-			pos:          Point{x, y},
+		BaseEntity: entity.BaseEntity{
+			pos:          entity.Point{x, y},
 			width:        w,
 			height:       h,
 			frame:        ImgProjectile,

--- a/v1/internal/game/tower.go
+++ b/v1/internal/game/tower.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"unicode"
 
+	"github.com/daddevv/type-defense/internal/entity"
 	"github.com/daddevv/type-defense/internal/tower"
 	"github.com/hajimehoshi/ebiten/v2"
 )
@@ -21,7 +22,7 @@ const (
 
 // Tower represents a stationary auto-firing tower.
 type Tower struct {
-	BaseEntity
+	entity.BaseEntity
 	cooldownTimer CooldownTimer // Use proper timer instead of float64
 	rate          float64       // seconds between shots
 	rangeDst      float64
@@ -89,8 +90,8 @@ func NewTowerWithTypeAndLevel(g *Game, x, y float64, tt TowerType, level int) *T
 	}
 
 	t := &Tower{
-		BaseEntity: BaseEntity{
-			pos:          Point{x, y},
+		BaseEntity: entity.BaseEntity{
+			pos:          entity.Point{x, y},
 			width:        w,
 			height:       h,
 			frame:        ImgTower,


### PR DESCRIPTION
## Summary
- relocate `Footman` and `OrcGrunt` types to `entity` package
- centralize base entity helpers under the `entity` module
- expose entity image assets and register them during `InitImages`
- update military and tests to use the new package

## Testing
- `go vet ./...` *(fails: unable to download modules)*
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842f73d65f88327addf369bbfdff0e1