### PR TITLE
Update internal docs and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,15 @@ any panic so unexpected crashes are easy to diagnose.
 
 ## Modular Handler Architecture
 
-Game logic is organized into modules under `internal/` (`entity`, `ui`, `tech`,
-`tower`, `phase`, `econ`, `sprite`, and `event`). Each module exposes a
-`Handler` with an `Update(dt)` method. Handlers communicate through a lightweight
-event bus, and `game.Game` coordinates rendering using the state from all
-handlers.
-For a deeper look at the pattern, see [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md).
+Game logic lives in the `v1/internal` directory. The original monolithic
+`game` package has been decomposed into several packages such as `assets`,
+`config`, `core`, `entity`, `mob`, `structure`, `worker`, `econ`, `word` and
+more. Each package exposes a `Handler` with an `Update(dt)` method. Handlers
+communicate through a lightweight event bus, and `game.Game` coordinates
+rendering using their state. See
+[docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md) and
+[docs/INTERNAL_RESTRUCTURE.md](docs/INTERNAL_RESTRUCTURE.md) for the import
+map and package descriptions.
 
 -## Current prototype
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,17 +29,13 @@
   - [x] **T-011** Write/adjust tests for new handler/event system
   - [x] **T-012** Document the new architecture and handler/event pattern for contributors
   - [x] **T-013** Ensure `game.Game` acts as main renderer, coordinating rendering using handler state
-  - [ ] **T-014** (Optional) Add migration/compatibility notes for contributors
-    - [ ] **MIG-001** Core engine & state management (`game.go`, `state.go`, `pregame.go`, `timer.go`, `settings.go`, `performance.go`)
-    - [ ] **MIG-002** Entities & units (`entity.go`, `mob.go`, `enemy.go`, `footman.go`, `orcgrunt.go`, `farmer.go`, `lumberjack.go`, `miner.go`)
-    - [ ] **MIG-003** Buildings & military (`barracks.go`, `base.go`, `military.go`)
-    - [ ] **MIG-004** Towers & projectiles (`tower.go`, `projectile.go`, `modifier.go`)
-    - [ ] **MIG-005** User interface components (`hud.go`, `mainmenu.go`, `skill_tree_overlay_test.go`, and related UI files)
-    - [ ] **MIG-006** Tech & skill systems (`tech.go`, `tech_tree.go`, `skill_tree.go`, `letter_unlocks.go`)
-    - [ ] **MIG-007** Resources & economy (`resource.go`, `queue.go`, `tile.go`, `point.go`)
-    - [ ] **MIG-008** Content and assets (`content.go`, `palette.go`, `font.go`, `sound.go`)
-    - [ ] **MIG-009** Typing metrics & stats (`typing_stats.go`, `word_stats.go`)
-    - [ ] **MIG-010** Update all related tests to new module paths
+  - [ ] **T-014** Finalize modular split and package renames
+    - [x] **MIG-001** Document package layout and import map (`INTERNAL_RESTRUCTURE.md`)
+    - [ ] **MIG-002** Rename `mob` package to `enemy`
+    - [ ] **MIG-003** Rename `structure` package to `building`
+    - [ ] **MIG-004** Move worker types under `building/gatherer`
+    - [ ] **MIG-005** Update all imports and tests after renames
+    - [ ] **MIG-006** Remove deprecated package references
 
 ---
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -4,16 +4,28 @@ This document summarizes the modular handler pattern introduced in the `v1` dire
 
 ## Module Layout
 
-All gameplay code lives under `v1/internal/`. Modules include:
+All gameplay code lives under `v1/internal/`. The packages were split out of a
+single `game` module and are organized as follows:
 
-- `entity` – ally and enemy units
-- `ui` – HUD, menus and overlays
-- `tech` – tech tree and skill tree logic
-- `tower` – towers, projectiles and related logic
-- `phase` – game state transitions
-- `content` – asset loading helpers
+- `assets` – fonts, palettes and other asset helpers
+- `config` – runtime configuration and defaults
+- `core` – timers, points, HUD helpers and other utilities
+- `event` – event bus and event type definitions
+- `econ` – resource structs and tech tree parsing
+- `word` – the global queue and typing statistics
+- `entity` – shared interfaces for drawable objects
+- `mob` – enemy implementations
+- `structure` – buildings, towers and the player base
+- `worker` – resource gathering buildings
 - `sprite` – image helpers and sprite utilities
-- `event` – event bus and event types
+- `input` – keyboard input processing
+- `phase` – game state enumeration helpers
+- `skill` – skill tree logic and persistence
+- `tech` – tech tree handler
+- `game` – the orchestrator that owns all handlers
+
+See [INTERNAL_RESTRUCTURE.md](INTERNAL_RESTRUCTURE.md) for the current import
+rules and planned renames.
 
 Each module exposes a `Handler` with an `Update(dt float64)` method. The `Handler` interface allows the main game engine to update modules in a uniform manner.
 

--- a/docs/INTERNAL_RESTRUCTURE.md
+++ b/docs/INTERNAL_RESTRUCTURE.md
@@ -1,0 +1,68 @@
+# Internal Package Restructure
+
+This document explains the current layout under `v1/internal` and outlines the permitted import
+relationships between packages. The goal is to keep the codebase modular and avoid import cycles as
+we continue to break the original monolithic `game` package into smaller components.
+
+## Current Modules
+
+```
+assets    config    core     event
+entity    mob       structure worker
+econ      word      sprite   input
+phase     skill     tech     game
+```
+
+- **assets** – fonts, palettes and helper functions for loading image/audio data.
+- **config** – runtime configuration and defaults.
+- **core** – miscellaneous utilities such as timers, points and HUD helpers.
+- **event** – the publish/subscribe event bus and event types.
+- **econ** – resource values and tech tree parsing.
+- **word** – the global queue, typing stats and word types.
+- **entity** – shared interfaces for anything that appears on screen.
+- **mob** – enemy implementations (currently various "Mob" types).
+- **structure** – buildings, towers and the player base.
+- **worker** – resource gathering buildings such as the Farmer and Miner.
+- **sprite** – helpers for image manipulation.
+- **input** – keyboard input processing.
+- **phase** – game state enumeration and helpers.
+- **skill** – skill tree logic and persistence.
+- **tech** – tech tree handler.
+- **game** – orchestrates all other handlers and owns the update loop.
+
+## Import Map
+
+The packages form a loose hierarchy. `game` imports every other package but nothing inside
+`internal/` should import `game`.
+
+**Base packages** (no internal imports):
+
+- `assets`
+- `config`
+- `core`
+- `event`
+
+**Domain packages** may import the base packages and each other only through defined
+interfaces. Avoid circular dependencies by following these guidelines:
+
+- `entity` imports `core` and `assets` only.
+- `mob` imports `assets`, `core`, `entity` and `structure`.
+- `structure` imports `assets`, `core`, `entity`, `econ` and `word`.
+- `worker` imports `assets`, `core`, `econ` and `word`.
+- `econ` and `word` do not depend on other domain packages.
+- `input`, `phase`, `skill`, `sprite` and `tech` depend only on base packages and optionally
+  on `econ` or `word` where required.
+- `game` depends on all of the above and ties them together.
+
+This import map ensures that assets, configuration and core utilities remain independent
+and that higher level systems communicate via events or well defined interfaces.
+
+## Planned Renames
+
+To better reflect their roles in the modular architecture we plan to rename several packages:
+
+- `mob` → `enemy`
+- `structure` → `building`
+- `worker` → `gatherer`
+
+These changes will occur once all dependent code is updated to the new package names.


### PR DESCRIPTION
## Summary
- document current internal module layout and import restrictions
- cross-link restructure guide in architecture overview and README
- refresh roadmap to capture rename tasks

## Testing
- `go test ./...` *(fails: "Forbidden" while downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68433ab544508327acec834ac069fbd6