### PR TITLE
Add unsubscribe to event bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Game logic lives in the `v1/internal` directory. The original monolithic
 `game` package has been decomposed into several packages such as `assets`,
 `config`, `core`, `entity`, `enemy`, `building` (with `gatherer` subpackage), `econ`, `word` and
 more. Each package exposes a `Handler` with an `Update(dt)` method. Handlers
-communicate through a lightweight event bus, and `game.Game` coordinates
+communicate through a lightweight event bus (with `Subscribe`/`Unsubscribe`), and `game.Game` coordinates
 rendering using their state. See
 [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md) and
 [docs/INTERNAL_RESTRUCTURE.md](docs/INTERNAL_RESTRUCTURE.md) for the import

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -32,6 +32,7 @@ Each module exposes a `Handler` with an `Update(dt float64)` method. The `Handle
 ## Event Bus
 
 `internal/event` provides a lightweight pub/sub system. Each handler exposes channels for its specific event type (for example `EntityEvents` or `UIEvents`). Handlers subscribe to the events they care about using the shared `EventBus` and communicate by publishing events.
+Handlers can stop receiving updates with `Unsubscribe` when they are done.
 
 Example:
 

--- a/v1/internal/event/event_bus.go
+++ b/v1/internal/event/event_bus.go
@@ -22,6 +22,19 @@ func (eb *EventBus) Subscribe(eventType string, ch chan Event) {
 	eb.subscribers[eventType] = append(eb.subscribers[eventType], ch)
 }
 
+// Unsubscribe removes a channel from receiving events of the given type.
+func (eb *EventBus) Unsubscribe(eventType string, ch chan Event) {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	subs := eb.subscribers[eventType]
+	for i, sub := range subs {
+		if sub == ch {
+			eb.subscribers[eventType] = append(subs[:i], subs[i+1:]...)
+			break
+		}
+	}
+}
+
 // Publish sends an event to all subscribers of its type.
 func (eb *EventBus) Publish(eventType string, evt Event) {
 	eb.mu.RLock()

--- a/v1/internal/event/event_bus_unsubscribe_test.go
+++ b/v1/internal/event/event_bus_unsubscribe_test.go
@@ -1,0 +1,18 @@
+//go:build test
+
+package event
+
+import "testing"
+
+func TestEventBusUnsubscribe(t *testing.T) {
+	bus := NewEventBus()
+	ch := make(chan Event, 1)
+	bus.Subscribe("ui", ch)
+	bus.Unsubscribe("ui", ch)
+	bus.Publish("ui", UIEvent{Type: "notice"})
+	select {
+	case <-ch:
+		t.Fatalf("received event after unsubscribe")
+	default:
+	}
+}


### PR DESCRIPTION
## Summary
- implement `EventBus.Unsubscribe`
- document unsubscribe usage
- add `TestEventBusUnsubscribe`

## Testing
- `go test -tags=test ./internal/event -v`
- `go test -tags=test ./...` *(fails: github.com/hajimehoshi/ebiten/v2 download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843670a391c83279a3824b8878c347b