### PR TITLE
Add event type enums

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -46,6 +46,11 @@ bus.Subscribe("ui", uiCh)
 
 The `game.Game` struct owns a pointer to every handler and the shared `EventBus`. During `Game.Update` each handler's `Update` method is called. Rendering is also coordinated by `game.Game` using state from these handlers.
 
+Event names are defined as string constants in `internal/event/event.go`. They
+are grouped by subsystem—`Building`, `Typing`, `Combat`, `Tech`, `Economy`,
+`Special`, `Testing`, and `Persistence`. Handlers publish and subscribe using
+these constants so updates remain decoupled but well documented.
+
 ## Adding New Features
 
 1. Create a new module under `internal/` if needed and define a `Handler`.

--- a/v1/internal/event/event.go
+++ b/v1/internal/event/event.go
@@ -49,3 +49,89 @@ type SpriteEvent struct {
 // Example: EntityHandler exposes EntityEvents chan Event, etc.
 
 // Example: Add more event types as needed for other modules.
+
+// -----------------------------------------------------------------------------
+// Event name constants
+
+// Building events cover construction, upgrades and cooldowns.
+type BuildingEventType string
+
+const (
+	BuildingPlaced    BuildingEventType = "BuildingPlaced"
+	BuildingDestroyed BuildingEventType = "BuildingDestroyed"
+	BuildingPaused    BuildingEventType = "BuildingPaused"
+	BuildingUnpaused  BuildingEventType = "BuildingUnpaused"
+	BuildingLeveledUp BuildingEventType = "BuildingLeveledUp"
+	CooldownComplete  BuildingEventType = "CooldownComplete"
+)
+
+// Typing events track player input and global queue status.
+type TypingEventType string
+
+const (
+	WordQueued           TypingEventType = "WordQueued"
+	WordLetterTyped      TypingEventType = "WordLetterTyped"
+	WordMistyped         TypingEventType = "WordMistyped"
+	WordBackspaced       TypingEventType = "WordBackspaced"
+	WordCompleted        TypingEventType = "WordCompleted"
+	QueueBacklogOverload TypingEventType = "QueueBacklogOverload"
+)
+
+// Combat events represent unit actions and damage resolution.
+type CombatEventType string
+
+const (
+	UnitSpawned        CombatEventType = "UnitSpawned"
+	UnitMoved          CombatEventType = "UnitMoved"
+	UnitTargetAcquired CombatEventType = "UnitTargetAcquired"
+	UnitTakesDamage    CombatEventType = "UnitTakesDamage"
+	UnitDied           CombatEventType = "UnitDied"
+	CombatTick         CombatEventType = "CombatTick"
+	CritHit            CombatEventType = "CritHit"
+)
+
+// Tech events are emitted from the tech and skill tree systems.
+type TechEventType string
+
+const (
+	TechNodeUnlocked TechEventType = "TechNodeUnlocked"
+	TechNodeFailed   TechEventType = "TechNodeFailed"
+	SkillUnlocked    TechEventType = "SkillUnlocked"
+	LetterUnlocked   TechEventType = "LetterUnlocked"
+)
+
+// Econ events deal with resource generation and spending.
+type EconomyEventType string
+
+const (
+	ResourceGained    EconomyEventType = "ResourceGained"
+	ResourceSpent     EconomyEventType = "ResourceSpent"
+	KingPointsChanged EconomyEventType = "KingPointsChanged"
+)
+
+// Special events are miscellaneous gameplay triggers.
+type SpecialEventType string
+
+const (
+	SpellCast      SpecialEventType = "SpellCast"
+	CritTriggered  SpecialEventType = "CritTriggered"
+	EventTriggered SpecialEventType = "EventTriggered"
+)
+
+// Testing events are used by automated or headless runs.
+type TestingEventType string
+
+const (
+	SimulationStart        TestingEventType = "SimulationStart"
+	SimulationStepComplete TestingEventType = "SimulationStepComplete"
+	GameStateSnapshot      TestingEventType = "GameStateSnapshot"
+)
+
+// Persistence events are fired when saving/loading game state.
+type PersistenceEventType string
+
+const (
+	GameSaved       PersistenceEventType = "GameSaved"
+	GameLoaded      PersistenceEventType = "GameLoaded"
+	SaveSlotCorrupt PersistenceEventType = "SaveSlotCorrupt"
+)


### PR DESCRIPTION
## Summary
- define event name constants grouped by subsystem
- document available event names in architecture overview

## Testing
- `go test ./...` *(fails: Forbidden to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_6843729c8a9c8327b908d34c0e34d3aa