### PR TITLE
Implement EventHandler and entity event channel

### DIFF
--- a/v1/internal/entity/handler.go
+++ b/v1/internal/entity/handler.go
@@ -1,5 +1,7 @@
 package entity
 
+import "github.com/daddevv/type-defense/internal/event"
+
 // EntityHandler defines the API for entity logic and state management.
 type EntityHandler interface {
 	Update(dt float64)
@@ -7,12 +9,14 @@ type EntityHandler interface {
 
 // EntityHandler manages all entity logic and state.
 type Handler struct {
-	// Add fields for entity state here
+	// Events is the outbound channel for entity-related events.
+	// Consumers can subscribe via the central event bus.
+	Events chan event.Event
 }
 
 // NewHandler creates a new EntityHandler.
 func NewHandler() *Handler {
-	return &Handler{}
+	return &Handler{Events: make(chan event.Event, 8)}
 }
 
 // Update updates all entities managed by the handler.

--- a/v1/internal/event/event_handler.go
+++ b/v1/internal/event/event_handler.go
@@ -1,0 +1,57 @@
+package event
+
+import "sync"
+
+// EventHandler routes events from handler channels through the EventBus.
+// Handlers register their outbound channels with Register so events are
+// published to the bus automatically.
+type EventHandler struct {
+	bus  *EventBus
+	quit chan struct{}
+	wg   sync.WaitGroup
+}
+
+// NewEventHandler creates a new EventHandler using the provided bus. If bus is
+// nil a new EventBus is created.
+func NewEventHandler(bus *EventBus) *EventHandler {
+	if bus == nil {
+		bus = NewEventBus()
+	}
+	return &EventHandler{bus: bus, quit: make(chan struct{})}
+}
+
+// Register begins forwarding all events received on ch to the bus using the
+// given event type.
+func (h *EventHandler) Register(eventType string, ch <-chan Event) {
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		for {
+			select {
+			case evt, ok := <-ch:
+				if !ok {
+					return
+				}
+				h.bus.Publish(eventType, evt)
+			case <-h.quit:
+				return
+			}
+		}
+	}()
+}
+
+// Subscribe registers a subscriber channel for a specific event type.
+func (h *EventHandler) Subscribe(eventType string, ch chan Event) {
+	h.bus.Subscribe(eventType, ch)
+}
+
+// Unsubscribe removes a subscriber channel for a specific event type.
+func (h *EventHandler) Unsubscribe(eventType string, ch chan Event) {
+	h.bus.Unsubscribe(eventType, ch)
+}
+
+// Stop stops all forwarding goroutines and waits for them to finish.
+func (h *EventHandler) Stop() {
+	close(h.quit)
+	h.wg.Wait()
+}

--- a/v1/internal/event/event_handler_test.go
+++ b/v1/internal/event/event_handler_test.go
@@ -1,0 +1,29 @@
+//go:build test
+
+package event
+
+import "testing"
+
+func TestEventHandlerRoutesEvents(t *testing.T) {
+	bus := NewEventBus()
+	h := NewEventHandler(bus)
+	pub := make(chan Event, 1)
+	sub := make(chan Event, 1)
+
+	h.Register("entity", pub)
+	h.Subscribe("entity", sub)
+
+	pub <- EntityEvent{Type: "spawn", Payload: "orc"}
+
+	select {
+	case e := <-sub:
+		ev, ok := e.(EntityEvent)
+		if !ok || ev.Type != "spawn" || ev.Payload != "orc" {
+			t.Fatalf("unexpected event: %#v", e)
+		}
+	default:
+		t.Fatalf("no event routed")
+	}
+
+	h.Stop()
+}


### PR DESCRIPTION
## Summary
- add an `Events` channel to the entity handler
- create central `EventHandler` that forwards events to the bus
- test that the event handler routes messages

## Testing
- `go vet ./...` *(fails: github.com and gopkg.in modules blocked)*
- `go test ./...` *(fails: github.com and gopkg.in modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6843801ac3b48327a64cec2a51b4d0c1